### PR TITLE
upipe-ts: keep invalid packets with a 0-length payload

### DIFF
--- a/lib/upipe-ts/upipe_ts_decaps.c
+++ b/lib/upipe-ts/upipe_ts_decaps.c
@@ -138,8 +138,12 @@ static void upipe_ts_decaps_input(struct upipe *upipe, struct uref *uref,
         if (unlikely((!has_payload && af_length != 183) ||
                      (has_payload && af_length >= 183))) {
             upipe_warn(upipe, "invalid adaptation field received");
-            uref_free(uref);
-            return;
+            /* keep invalid packets with a 0-length payload because
+             * it is a common error in the field */
+            if (!(has_payload && af_length == 183)) {
+                uref_free(uref);
+                return;
+            }
         }
 
         if (af_length) {


### PR DESCRIPTION
Keep packets with this kind of invalid adaptation field because they are
commonly found in publicly available HLS streams.