### PR TITLE
Enable automake silent rules by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
 
 before_script: autoreconf -i
 
-script: ./configure
+script: ./configure --disable-silent-rules
           CPPFLAGS="-I$PWD/nacl_sdk/pepper_43/include"
           LDFLAGS="-L$PWD/nacl_sdk/pepper_43/lib/glibc_x86_64" &&
         make &&

--- a/configure.ac
+++ b/configure.ac
@@ -8,7 +8,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([autotools])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([foreign nostdinc parallel-tests color-tests subdir-objects])
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([no])])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 PKG_PROG_PKG_CONFIG
 
 # Checks for programs.


### PR DESCRIPTION
Makes it easier to see warnings.