### PR TITLE
upipe-ts: ts-demux depends on setrap which is in upipe-modules. Fix p…

### DIFF
--- a/lib/upipe-ts/libupipe_ts.pc.in
+++ b/lib/upipe-ts/libupipe_ts.pc.in
@@ -5,6 +5,6 @@ includedir=@includedir@
 Name: libupipe_ts
 Description: Upipe multimedia framework, MPEG-2 transport stream modules
 Version: @VERSION@
-Requires: libupipe
+Requires: libupipe libupipe_modules
 Libs: -L${libdir} -lupipe_ts
 Cflags: -I${includedir}


### PR DESCRIPTION
…kgconfig file accordingly