### PR TITLE
avutil: Use AV_PIX_FMT rather than PIX_FMT

### DIFF
--- a/include/upipe-av/upipe_av_pixfmt.h
+++ b/include/upipe-av/upipe_av_pixfmt.h
@@ -53,7 +53,7 @@ extern "C" {
  * @param flow_def overwritten flow definition
  * @return an error code
  */
-static inline int upipe_av_pixfmt_to_flow_def(enum PixelFormat pix_fmt,
+static inline int upipe_av_pixfmt_to_flow_def(enum AVPixelFormat pix_fmt,
                                               struct uref *flow_def)
 {
     UBASE_RETURN(uref_pic_flow_set_planes(flow_def, 0))
@@ -201,15 +201,15 @@ static inline int upipe_av_pixfmt_to_flow_def(enum PixelFormat pix_fmt,
  * @param flow_def flow definition
  * @param pix_fmts allowed pixel formats, terminated by -1 (or NULL for any)
  * @param chroma_map av plane number vs. chroma map
- * @return selected pixel format, or PIX_FMT_NONE if no compatible pixel format
+ * @return selected pixel format, or AV_PIX_FMT_NONE if no compatible pixel format
  * was found
  */
-static inline enum PixelFormat
+static inline enum AVPixelFormat
     upipe_av_pixfmt_from_flow_def(struct uref *flow_def,
-                                  const enum PixelFormat *pix_fmts,
+                                  const enum AVPixelFormat *pix_fmts,
                                   const char *chroma_p[UPIPE_AV_MAX_PLANES])
 {
-    static const enum PixelFormat supported_fmts[] = {
+    static const enum AVPixelFormat supported_fmts[] = {
         AV_PIX_FMT_YUV420P,
         AV_PIX_FMT_YUVJ420P,
         AV_PIX_FMT_YUV422P,

--- a/lib/upipe-av/upipe_avcodec_decode.c
+++ b/lib/upipe-av/upipe_avcodec_decode.c
@@ -117,7 +117,7 @@ struct upipe_avcdec {
     /** upump mgr */
     struct upump_mgr *upump_mgr;
     /** pixel format used for the ubuf manager */
-    enum PixelFormat pix_fmt;
+    enum AVPixelFormat pix_fmt;
     /** sample format used for the ubuf manager */
     enum AVSampleFormat sample_fmt;
     /** number of channels used for the ubuf manager */
@@ -1417,7 +1417,7 @@ static struct upipe *upipe_avcdec_alloc(struct upipe_mgr *mgr,
     upipe_avcdec->frame = frame;
     upipe_avcdec->counter = 0;
     upipe_avcdec->close = false;
-    upipe_avcdec->pix_fmt = PIX_FMT_NONE;
+    upipe_avcdec->pix_fmt = AV_PIX_FMT_NONE;
     upipe_avcdec->sample_fmt = AV_SAMPLE_FMT_NONE;
     upipe_avcdec->channels = 0;
     upipe_avcdec->uref = NULL;

--- a/lib/upipe-swscale/upipe_sws.c
+++ b/lib/upipe-swscale/upipe_sws.c
@@ -104,9 +104,9 @@ struct upipe_sws {
     /** swscale image conversion context [0] for progressive, [1,2] interlaced */
     struct SwsContext *convert_ctx[3];
     /** input pixel format */
-    enum PixelFormat input_pix_fmt;
+    enum AVPixelFormat input_pix_fmt;
     /** requested output pixel format */
-    enum PixelFormat output_pix_fmt;
+    enum AVPixelFormat output_pix_fmt;
     /** input chroma map */
     const char *input_chroma_map[UPIPE_AV_MAX_PLANES];
     /** output chroma map */

--- a/lib/upipe-swscale/upipe_sws_thumbs.c
+++ b/lib/upipe-swscale/upipe_sws_thumbs.c
@@ -114,9 +114,9 @@ struct upipe_sws_thumbs {
     struct picsize *thumbnum;
 
     /** input pixel format */
-    enum PixelFormat input_pix_fmt;
+    enum AVPixelFormat input_pix_fmt;
     /** requested output pixel format */
-    enum PixelFormat output_pix_fmt;
+    enum AVPixelFormat output_pix_fmt;
     /** input chroma map */
     const char *input_chroma_map[UPIPE_AV_MAX_PLANES];
     /** output chroma map */

--- a/tests/upipe_sws_test.c
+++ b/tests/upipe_sws_test.c
@@ -272,7 +272,7 @@ static struct upipe_mgr sws_test_mgr = {
 };
 
 // DEBUG - from swscale/swscale_unscaled.c
-static int check_image_pointers(const uint8_t * const data[4], enum PixelFormat pix_fmt, const int linesizes[4])
+static int check_image_pointers(const uint8_t * const data[4], enum AVPixelFormat pix_fmt, const int linesizes[4])
 {
     const AVPixFmtDescriptor *desc = &av_pix_fmt_descriptors[pix_fmt];
     int i;
@@ -345,8 +345,8 @@ int main(int argc, char **argv)
     ubase_assert(uref_pic_set_progressive(uref2));
 
     img_convert_ctx = sws_getCachedContext(NULL,
-                SRCSIZE, SRCSIZE, PIX_FMT_YUV420P,
-                DSTSIZE, DSTSIZE, PIX_FMT_YUV420P,
+                SRCSIZE, SRCSIZE, AV_PIX_FMT_YUV420P,
+                DSTSIZE, DSTSIZE, AV_PIX_FMT_YUV420P,
                 SWS_FULL_CHR_H_INP | SWS_ACCURATE_RND | SWS_LANCZOS,
                 NULL, NULL, NULL);
     assert(img_convert_ctx);
@@ -361,8 +361,8 @@ int main(int argc, char **argv)
     assert(strides[1]);
     assert(strides[2]);
 
-    assert(check_image_pointers((const uint8_t * const*) slices, PIX_FMT_YUV420P, strides));
-    assert(check_image_pointers((const uint8_t * const*) dslices, PIX_FMT_YUV420P, dstrides));
+    assert(check_image_pointers((const uint8_t * const*) slices, AV_PIX_FMT_YUV420P, strides));
+    assert(check_image_pointers((const uint8_t * const*) dslices, AV_PIX_FMT_YUV420P, dstrides));
 
     // fire raw swscale test
     ret = sws_scale(img_convert_ctx, (const uint8_t * const*) slices, strides,


### PR DESCRIPTION
PixelFormat was renamed to AVPixelFormat as well.
This is visible now that the old versions have been removed

http://git.videolan.org/gitweb.cgi/ffmpeg.git/?a=commit;h=183db02a51a422568084b113a7571c845ca68622