### PR TITLE
FFmpeg API update

### DIFF
--- a/lib/upipe-av/upipe_avcodec_decode.c
+++ b/lib/upipe-av/upipe_avcodec_decode.c
@@ -384,7 +384,6 @@ static int upipe_avcdec_get_buffer_pic(struct AVCodecContext *context,
         frame->linesize[plane] = stride;
     }
     frame->extended_data = frame->data;
-    frame->type = FF_BUFFER_TYPE_USER;
 
     return 0; /* success */
 }
@@ -537,7 +536,6 @@ static int upipe_avcdec_get_buffer_sound(struct AVCodecContext *context,
         frame->linesize[0] *= context->channels;
 
     frame->extended_data = frame->data;
-    frame->type = FF_BUFFER_TYPE_USER;
 
     return 0; /* success */
 }

--- a/lib/upipe-av/upipe_avcodec_decode.c
+++ b/lib/upipe-av/upipe_avcodec_decode.c
@@ -354,7 +354,7 @@ static int upipe_avcdec_get_buffer_pic(struct AVCodecContext *context,
 
     if (!(context->codec->capabilities & CODEC_CAP_DR1)) {
         upipe_verbose(upipe, "no direct rendering, using default");
-        return avcodec_default_get_buffer(context, frame);
+        return avcodec_default_get_buffer2(context, frame, 0);
     }
 
     /* Direct rendering */
@@ -518,7 +518,7 @@ static int upipe_avcdec_get_buffer_sound(struct AVCodecContext *context,
     uref->uchain.next = uref_to_uchain(flow_def_attr);
 
     if (!(context->codec->capabilities & CODEC_CAP_DR1))
-        return avcodec_default_get_buffer(context, frame);
+        return avcodec_default_get_buffer2(context, frame, 0);
 
     /* Direct rendering */
     if (unlikely(!ubase_check(ubuf_sound_write_uint8_t(ubuf, 0, -1, frame->data,

--- a/lib/upipe-av/upipe_avcodec_decode.c
+++ b/lib/upipe-av/upipe_avcodec_decode.c
@@ -1364,7 +1364,7 @@ static void upipe_avcdec_free(struct upipe *upipe)
         free(upipe_avcdec->context->extradata);
         av_free(upipe_avcdec->context);
     }
-    av_free(upipe_avcdec->frame);
+    av_frame_free(&upipe_avcdec->frame);
 
     upipe_throw_dead(upipe);
     uref_free(upipe_avcdec->uref);
@@ -1394,13 +1394,13 @@ static struct upipe *upipe_avcdec_alloc(struct upipe_mgr *mgr,
                                         struct uprobe *uprobe,
                                         uint32_t signature, va_list args)
 {
-    AVFrame *frame = avcodec_alloc_frame();
+    AVFrame *frame = av_frame_alloc();
     if (unlikely(frame == NULL))
         return NULL;
 
     struct upipe *upipe = upipe_avcdec_alloc_void(mgr, uprobe, signature, args);
     if (unlikely(upipe == NULL)) {
-        av_free(frame);
+        av_frame_free(&frame);
         return NULL;
     }
     upipe_avcdec_init_urefcount(upipe);

--- a/lib/upipe-av/upipe_avcodec_encode.c
+++ b/lib/upipe-av/upipe_avcodec_encode.c
@@ -1443,7 +1443,7 @@ static void upipe_avcenc_free(struct upipe *upipe)
 
     if (upipe_avcenc->context != NULL)
         av_free(upipe_avcenc->context);
-    av_free(upipe_avcenc->frame);
+    av_frame_free(&upipe_avcenc->frame);
 
     /* free remaining urefs (should not be any) */
     struct uchain *uchain;
@@ -1482,7 +1482,7 @@ static struct upipe *upipe_avcenc_alloc(struct upipe_mgr *mgr,
                                         struct uprobe *uprobe,
                                         uint32_t signature, va_list args)
 {
-    AVFrame *frame = avcodec_alloc_frame();
+    AVFrame *frame = av_frame_alloc();
     if (unlikely(frame == NULL))
         return NULL;
 
@@ -1490,7 +1490,7 @@ static struct upipe *upipe_avcenc_alloc(struct upipe_mgr *mgr,
     struct upipe *upipe = upipe_avcenc_alloc_flow(mgr, uprobe, signature, args,
                                                   &flow_def);
     if (unlikely(upipe == NULL)) {
-        av_free(frame);
+        av_frame_free(&frame);
         return NULL;
     }
 
@@ -1510,7 +1510,7 @@ static struct upipe *upipe_avcenc_alloc(struct upipe_mgr *mgr,
     if ((codec == NULL) ||
             (upipe_avcenc->context = avcodec_alloc_context3(codec)) == NULL) {
         uref_free(flow_def);
-        av_free(frame);
+        av_frame_free(&frame);
         upipe_avcenc_free_flow(upipe);
         return NULL;
     }

--- a/tests/upipe_sws_test.c
+++ b/tests/upipe_sws_test.c
@@ -274,7 +274,7 @@ static struct upipe_mgr sws_test_mgr = {
 // DEBUG - from swscale/swscale_unscaled.c
 static int check_image_pointers(const uint8_t * const data[4], enum AVPixelFormat pix_fmt, const int linesizes[4])
 {
-    const AVPixFmtDescriptor *desc = &av_pix_fmt_descriptors[pix_fmt];
+    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(pix_fmt);
     int i;
 
     for (i = 0; i < 4; i++) {


### PR DESCRIPTION
Preparation for refcounted buffers

These changes were build-tested with FFmpeg 2.5

FFmpeg 2.4 doesn't build anymore:
error: ‘struct AVCodecContext’ has no member named ‘framerate’
error: ‘AV_CODEC_ID_APNG’ undeclared here (not in a function)
error: ‘AV_CODEC_ID_STL’ undeclared here (not in a function)