### PR TITLE
Bring back uref_block_extend from 55001e8

### DIFF
--- a/include/upipe/ubuf_block.h
+++ b/include/upipe/ubuf_block.h
@@ -479,6 +479,34 @@ static inline int ubuf_block_resize(struct ubuf *ubuf, int offset, int new_size)
     return UBASE_ERR_NONE;
 }
 
+/** @This prepends a block ubuf, if possible. This will only work if
+ * prepend has been correctly specified at allocation.
+ *
+ * Should this fail, @ref ubuf_block_merge may be used to achieve the same
+ * goal with an extra buffer copy.
+ *
+ * @param ubuf pointer to ubuf
+ * @param prepend number of octets to prepend
+ * @return an error code
+ */
+static inline int ubuf_block_prepend(struct ubuf *ubuf, int prepend)
+{
+    assert(prepend >= 0);
+    if (ubuf->mgr->signature != UBUF_ALLOC_BLOCK)
+        return UBASE_ERR_INVALID;
+
+    struct ubuf_block *block = ubuf_block_from_ubuf(ubuf);
+
+    if (prepend > block->offset)
+        return UBASE_ERR_INVALID;
+
+    block->offset -= prepend;
+    block->size += prepend;
+    block->total_size += prepend;
+    block->cached_offset += prepend;
+    return UBASE_ERR_NONE;
+}
+
 /** @This duplicates part of a ubuf.
  *
  * @param ubuf pointer to ubuf

--- a/include/upipe/ubuf_block_mem.h
+++ b/include/upipe/ubuf_block_mem.h
@@ -49,6 +49,8 @@ struct umem_mgr;
  * @param ubuf_pool_depth maximum number of ubuf structures in the pool
  * @param shared_pool_depth maximum number of shared structures in the pool
  * @param umem_mgr memory allocator to use for buffers
+ * @param prepend default minimum extra space before buffer (if set to -1, a
+ * default sensible value is used)
  * @param align default alignment in octets (if set to -1, a default sensible
  * value is used)
  * @param align_offset offset of the aligned octet, in octets (may be negative)
@@ -57,6 +59,7 @@ struct umem_mgr;
 struct ubuf_mgr *ubuf_block_mem_mgr_alloc(uint16_t ubuf_pool_depth,
                                           uint16_t shared_pool_depth,
                                           struct umem_mgr *umem_mgr,
+                                          int prepend,
                                           int align, int align_offset);
 
 #ifdef __cplusplus

--- a/include/upipe/uref_block.h
+++ b/include/upipe/uref_block.h
@@ -157,6 +157,14 @@ static inline int uref_block_resize(struct uref *uref, int skip, int new_size)
     return ubuf_block_resize(uref->ubuf, skip, new_size);
 }
 
+/** @see ubuf_block_prepend */
+static inline int uref_block_prepend(struct uref *uref, int prepend)
+{
+    if (uref->ubuf == NULL)
+        return UBASE_ERR_INVALID;
+    return ubuf_block_prepend(uref->ubuf, prepend);
+}
+
 /** @see ubuf_block_splice */
 static inline struct uref *uref_block_splice(struct uref *uref, int offset,
                                              int size)

--- a/include/upipe/uref_block_flow.h
+++ b/include/upipe/uref_block_flow.h
@@ -53,6 +53,8 @@ UREF_ATTR_UNSIGNED(block_flow, buffer_size, "b.bs",
 UREF_ATTR_UNSIGNED(block_flow, max_buffer_size, "b.max_bs",
         maximum size of coded buffer in octets)
 UREF_ATTR_UNSIGNED(block_flow, align, "b.align", alignment in octets)
+UREF_ATTR_UNSIGNED(block_flow, prepend, "b.prepend",
+        extra bytes allocated before buffer)
 UREF_ATTR_INT(block_flow, align_offset, "b.align_offset",
         offset of the aligned octet)
 UREF_ATTR_UNSIGNED(block_flow, size, "b.size", block size)

--- a/lib/upipe/ubuf_mem.c
+++ b/lib/upipe/ubuf_mem.c
@@ -61,10 +61,12 @@ struct ubuf_mgr *ubuf_mem_mgr_alloc_from_flow_def(uint16_t ubuf_pool_depth,
     if (!ubase_ncmp(def, "block.")) {
         uint64_t align = 0;
         int64_t align_offset = 0;
+        uint64_t prepend = 0;
         uref_block_flow_get_align(flow_def, &align);
         uref_block_flow_get_align_offset(flow_def, &align_offset);
+        uref_block_flow_get_prepend(flow_def, &prepend);
         return ubuf_block_mem_mgr_alloc(ubuf_pool_depth, shared_pool_depth,
-                                        umem_mgr, align, align_offset);
+                                        umem_mgr, prepend, align, align_offset);
     }
 
     if (!ubase_ncmp(def, "pic.")) {

--- a/tests/ubuf_block_mem_test.c
+++ b/tests/ubuf_block_mem_test.c
@@ -52,6 +52,7 @@ int main(int argc, char **argv)
     assert(umem_mgr != NULL);
     struct ubuf_mgr *mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                     UBUF_POOL_DEPTH, umem_mgr,
+                                                    UBUF_PREPEND,
                                                     UBUF_ALIGN,
                                                     UBUF_ALIGN_OFFSET);
     assert(mgr != NULL);
@@ -107,6 +108,15 @@ int main(int argc, char **argv)
     assert(wanted == UBUF_SIZE);
     assert(r[0] == 1);
     assert(r[UBUF_SIZE - 1] == UBUF_SIZE);
+    ubase_assert(ubuf_block_unmap(ubuf1, 0));
+
+    /* test ubuf_block_prepend */
+    ubase_assert(ubuf_block_prepend(ubuf1, UBUF_PREPEND));
+    wanted = -1;
+    ubase_assert(ubuf_block_read(ubuf1, 0, &wanted, &r));
+    assert(wanted == UBUF_SIZE + UBUF_PREPEND);
+    assert(r[UBUF_PREPEND] == 1);
+    assert(r[UBUF_SIZE + UBUF_PREPEND - 1] == UBUF_SIZE);
     ubase_assert(ubuf_block_unmap(ubuf1, 0));
 
     ubuf_free(ubuf1);

--- a/tests/upipe_a52_framer_test.c
+++ b/tests/upipe_a52_framer_test.c
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_aggregate_test.c
+++ b/tests/upipe_aggregate_test.c
@@ -141,7 +141,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_avcodec_decode_test.c
+++ b/tests/upipe_avcodec_decode_test.c
@@ -340,6 +340,7 @@ int main (int argc, char **argv)
     /* block */
     block_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
             UBUF_POOL_DEPTH, umem_mgr,
+            UBUF_PREPEND,
             UBUF_ALIGN,
             UBUF_ALIGN_OFFSET);
     assert(block_mgr);

--- a/tests/upipe_chunk_stream_test.c
+++ b/tests/upipe_chunk_stream_test.c
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_htons_test.c
+++ b/tests/upipe_htons_test.c
@@ -157,7 +157,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_mpga_framer_test.c
+++ b/tests/upipe_mpga_framer_test.c
@@ -165,7 +165,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_mpgv_framer_test.c
+++ b/tests/upipe_mpgv_framer_test.c
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_multicat_test.c
+++ b/tests/upipe_multicat_test.c
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct upump_mgr *upump_mgr = upump_ev_mgr_alloc(loop, UPUMP_POOL,
                                                      UPUMP_BLOCKER_POOL);

--- a/tests/upipe_rtp_decaps_test.c
+++ b/tests/upipe_rtp_decaps_test.c
@@ -164,6 +164,7 @@ int main(int argc, char **argv)
     /* block */
     struct ubuf_mgr *block_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
             UBUF_POOL_DEPTH, umem_mgr,
+            UBUF_PREPEND,
             UBUF_ALIGN,
             UBUF_ALIGN_OFFSET);
     assert(block_mgr);

--- a/tests/upipe_rtp_prepend_test.c
+++ b/tests/upipe_rtp_prepend_test.c
@@ -216,6 +216,7 @@ int main(int argc, char **argv)
     /* block */
     ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                     UBUF_POOL_DEPTH, umem_mgr,
+                                                    0,
                                                     UBUF_ALIGN,
                                                     UBUF_ALIGN_OFFSET);
     assert(ubuf_mgr);

--- a/tests/upipe_skip_test.c
+++ b/tests/upipe_skip_test.c
@@ -169,6 +169,7 @@ int main(int argc, char **argv)
     /* block */
     struct ubuf_mgr *block_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
             UBUF_POOL_DEPTH, umem_mgr,
+            UBUF_PREPEND,
             UBUF_ALIGN,
             UBUF_ALIGN_OFFSET);
     assert(block_mgr);

--- a/tests/upipe_ts_check_test.c
+++ b/tests/upipe_ts_check_test.c
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_decaps_test.c
+++ b/tests/upipe_ts_decaps_test.c
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_demux_test.c
+++ b/tests/upipe_ts_demux_test.c
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_eit_decoder_test.c
+++ b/tests/upipe_ts_eit_decoder_test.c
@@ -168,7 +168,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_encaps_test.c
+++ b/tests/upipe_ts_encaps_test.c
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_nit_decoder_test.c
+++ b/tests/upipe_ts_nit_decoder_test.c
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_pat_decoder_test.c
+++ b/tests/upipe_ts_pat_decoder_test.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_pes_decaps_test.c
+++ b/tests/upipe_ts_pes_decaps_test.c
@@ -169,7 +169,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_pes_encaps_test.c
+++ b/tests/upipe_ts_pes_encaps_test.c
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_pid_filter_test.c
+++ b/tests/upipe_ts_pid_filter_test.c
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_pmt_decoder_test.c
+++ b/tests/upipe_ts_pmt_decoder_test.c
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_psi_generator_test.c
+++ b/tests/upipe_ts_psi_generator_test.c
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_psi_join_test.c
+++ b/tests/upipe_ts_psi_join_test.c
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_psi_merge_test.c
+++ b/tests/upipe_ts_psi_merge_test.c
@@ -158,7 +158,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_psi_split_test.c
+++ b/tests/upipe_ts_psi_split_test.c
@@ -172,7 +172,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_scte35_decoder_test.c
+++ b/tests/upipe_ts_scte35_decoder_test.c
@@ -211,7 +211,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_scte35_generator_test.c
+++ b/tests/upipe_ts_scte35_generator_test.c
@@ -191,7 +191,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_sdt_decoder_test.c
+++ b/tests/upipe_ts_sdt_decoder_test.c
@@ -147,7 +147,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_si_generator_test.c
+++ b/tests/upipe_ts_si_generator_test.c
@@ -341,7 +341,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_split_test.c
+++ b/tests/upipe_ts_split_test.c
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_sync_test.c
+++ b/tests/upipe_ts_sync_test.c
@@ -152,7 +152,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_tdt_decoder_test.c
+++ b/tests/upipe_ts_tdt_decoder_test.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_ts_tstd_test.c
+++ b/tests/upipe_ts_tstd_test.c
@@ -148,7 +148,7 @@ int main(int argc, char *argv[])
     assert(uref_mgr != NULL);
     struct ubuf_mgr *ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH,
                                                          UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct uprobe uprobe;
     uprobe_init(&uprobe, catch, NULL);

--- a/tests/upipe_udp_test.c
+++ b/tests/upipe_udp_test.c
@@ -265,7 +265,7 @@ int main(int argc, char *argv[])
     uref_mgr = uref_std_mgr_alloc(UREF_POOL_DEPTH, udict_mgr, 0);
     assert(uref_mgr != NULL);
     ubuf_mgr = ubuf_block_mem_mgr_alloc(UBUF_POOL_DEPTH, UBUF_POOL_DEPTH,
-                                                         umem_mgr, -1, 0);
+                                                         umem_mgr, 0, -1, 0);
     assert(ubuf_mgr != NULL);
     struct upump_mgr *upump_mgr = upump_ev_mgr_alloc(loop, UPUMP_POOL,
                                                      UPUMP_BLOCKER_POOL);


### PR DESCRIPTION
This can be used instead of less performant iovec when writing ubufs to DMA