### PR TITLE
Makefile.am: make the list of source files easily mergeable

### DIFF
--- a/include/upipe-blackmagic/Makefile.am
+++ b/include/upipe-blackmagic/Makefile.am
@@ -1,6 +1,8 @@
+NULL =
 myincludedir = $(includedir)/upipe-blackmagic
 myinclude_HEADERS = \
 	ubuf_pic_blackmagic.h \
 	ubuf_sound_blackmagic.h \
 	upipe_blackmagic_source.h \
-	upipe_blackmagic_extract_vanc.h
+	upipe_blackmagic_extract_vanc.h \
+	$(NULL)

--- a/include/upipe-framers/Makefile.am
+++ b/include/upipe-framers/Makefile.am
@@ -1,3 +1,4 @@
+NULL =
 myincludedir = $(includedir)/upipe-framers
 myinclude_HEADERS = \
 	upipe_h264_framer.h \
@@ -17,4 +18,5 @@ myinclude_HEADERS = \
 	uref_h265.h \
 	uref_h265_flow.h \
 	uref_mpga_flow.h \
-	uref_mpgv_flow.h
+	uref_mpgv_flow.h \
+	$(NULL)

--- a/include/upipe-modules/Makefile.am
+++ b/include/upipe-modules/Makefile.am
@@ -1,3 +1,4 @@
+NULL =
 myincludedir = $(includedir)/upipe-modules
 myinclude_HEADERS = \
 	upipe_transfer.h \
@@ -61,4 +62,5 @@ myinclude_HEADERS = \
 	upipe_sequential_source.h \
 	upipe_segment_source.h \
 	upipe_id3v2.h \
-	upipe_rtp_reorder.h
+	upipe_rtp_reorder.h \
+	$(NULL)

--- a/include/upipe-ts/Makefile.am
+++ b/include/upipe-ts/Makefile.am
@@ -1,3 +1,4 @@
+NULL =
 myincludedir = $(includedir)/upipe-ts
 myinclude_HEADERS = \
 	upipe_ts.h \
@@ -31,4 +32,5 @@ myinclude_HEADERS = \
 	uref_ts_attr.h \
 	uref_ts_event.h \
 	uref_ts_flow.h \
-	uref_ts_scte35.h
+	uref_ts_scte35.h \
+	$(NULL)

--- a/lib/upipe-blackmagic/Makefile.am
+++ b/lib/upipe-blackmagic/Makefile.am
@@ -1,9 +1,11 @@
+NULL =
 lib_LTLIBRARIES = libupipe_blackmagic.la
 
 libupipe_blackmagic_la_SOURCES = ubuf_pic_blackmagic.cpp \
                                  ubuf_sound_blackmagic.cpp \
                                  upipe_blackmagic_source.cpp \
-                                 upipe_blackmagic_extract_vanc.cpp
+                                 upipe_blackmagic_extract_vanc.cpp \
+                                 $(NULL)
 
 EXTRA_libupipe_blackmagic_la_SOURCES = include/DeckLinkAPIConfiguration.h \
                                        include/DeckLinkAPIDeckControl.h \

--- a/lib/upipe-framers/Makefile.am
+++ b/lib/upipe-framers/Makefile.am
@@ -1,3 +1,4 @@
+NULL =
 lib_LTLIBRARIES = libupipe_framers.la
 
 noinst_HEADERS = upipe_framers_common.h \
@@ -16,7 +17,8 @@ libupipe_framers_la_SOURCES = \
 	upipe_dvbsub_framer.c \
 	upipe_s302_framer.c \
 	upipe_s337_framer.c \
-	upipe_video_trim.c
+	upipe_video_trim.c \
+	$(NULL)
 
 libupipe_framers_la_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 libupipe_framers_la_LDFLAGS = -no-undefined

--- a/lib/upipe-modules/Makefile.am
+++ b/lib/upipe-modules/Makefile.am
@@ -1,3 +1,4 @@
+NULL =
 lib_LTLIBRARIES = libupipe_modules.la
 
 libupipe_modules_la_SOURCES = \
@@ -60,7 +61,8 @@ libupipe_modules_la_SOURCES = \
 	upipe_sequential_source.c \
 	upipe_segment_source.c \
 	upipe_id3v2.c \
-	id3v2.h
+	id3v2.h \
+	$(NULL)
 
 if HAVE_WRITEV
 libupipe_modules_la_SOURCES += \

--- a/lib/upipe-ts/Makefile.am
+++ b/lib/upipe-ts/Makefile.am
@@ -1,3 +1,4 @@
+NULL =
 lib_LTLIBRARIES = libupipe_ts.la
 
 noinst_HEADERS = upipe_ts_psi_decoder.h
@@ -28,7 +29,8 @@ libupipe_ts_la_SOURCES = \
 	upipe_ts_pes_encaps.c \
 	upipe_ts_psi_generator.c \
 	upipe_ts_si_generator.c \
-	upipe_ts_mux.c
+	upipe_ts_mux.c \
+	$(NULL)
 
 libupipe_ts_la_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 libupipe_ts_la_LIBADD = $(top_builddir)/lib/upipe-modules/libupipe_modules.la \


### PR DESCRIPTION
Adding a NULL entry at the end of the files list make every
line look the same with a trailing backslash.
This makes merging different trees easier when both trees have
added new files.

Do this for modules that changed recently