### PR TITLE
upipe-speexdsp: resample audio to cancel drift rate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
     - MAKEFLAGS=-j2
     - FFMPEG="libavcodec-ffmpeg-dev libavformat-ffmpeg-dev libswresample-ffmpeg-dev libswscale-ffmpeg-dev"
-    - APT_PACKAGES_COMMON="libev-dev libasound2-dev libx264-dev luajit $FFMPEG"
+    - APT_PACKAGES_COMMON="libev-dev libasound2-dev libx264-dev luajit libspeexdsp-dev $FFMPEG"
 
 matrix:
   include:
@@ -83,6 +83,7 @@ before_install:
       brew install yasm;
       brew install x264;
       brew install ffmpeg;
+      brew install speex;
       brew install luajit;
     fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ PKG_CHECK_UPIPE(AVUTIL, libavutil, [libavutil/avutil.h])
 PKG_CHECK_UPIPE(AVFORMAT, [libavformat >= 53.32.0 libavcodec libavutil], [libavformat/avformat.h libavformat/avio.h libavutil/avutil.h])
 PKG_CHECK_UPIPE(SWSCALE, libswscale >= 2.1.0 libavutil, [libswscale/swscale.h libavutil/avutil.h])
 PKG_CHECK_UPIPE(SWRESAMPLE, libswresample libavutil, [libswresample/swresample.h libavutil/avutil.h])
+PKG_CHECK_UPIPE(SPEEXDSP, speexdsp, [speex/speex_resampler.h])
 PKG_CHECK_UPIPE(GLX, gl glu x11, [GL/glx.h GL/glu.h GL/gl.h])
 PKG_CHECK_UPIPE(X264, x264, [x264.h])
 PKG_CHECK_UPIPE(ECORE, ecore, [Ecore.h])
@@ -166,6 +167,7 @@ AC_CONFIG_FILES([Makefile
                  include/upipe-osx/Makefile
                  include/upipe-alsa/Makefile
                  include/upipe-swresample/Makefile
+                 include/upipe-speexdsp/Makefile
                  include/upipe-blackmagic/Makefile
                  include/upipe-qt/Makefile
                  include/upipe-nacl/Makefile
@@ -204,6 +206,8 @@ AC_CONFIG_FILES([Makefile
                  lib/upipe-alsa/libupipe_alsa.pc
                  lib/upipe-swresample/Makefile
                  lib/upipe-swresample/libupipe_swresample.pc
+                 lib/upipe-speexdsp/Makefile
+                 lib/upipe-speexdsp/libupipe_speexdsp.pc
                  lib/upipe-blackmagic/Makefile
                  lib/upipe-blackmagic/libupipe_blackmagic.pc
                  lib/upipe-qt/Makefile

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -40,6 +40,10 @@ if HAVE_SWRESAMPLE
 SUBDIRS += upipe-swresample
 endif
 
+if HAVE_SPEEXDSP
+SUBDIRS += upipe-speexdsp
+endif
+
 if HAVE_DLFCN_H
 SUBDIRS += upipe-blackmagic
 endif

--- a/include/upipe-speexdsp/Makefile.am
+++ b/include/upipe-speexdsp/Makefile.am
@@ -1,0 +1,3 @@
+myincludedir = $(includedir)/upipe-speexdsp
+myinclude_HEADERS = \
+	upipe_speexdsp.h

--- a/include/upipe-speexdsp/upipe_speexdsp.h
+++ b/include/upipe-speexdsp/upipe_speexdsp.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 Open Broadcast Systems Ltd
+ *
+ * Authors: Rafaël Carré <funman@videolan.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/** @file
+ * @short Upipe speexdsp resampler module
+ */
+
+#ifndef _UPIPE_MODULES_UPIPE_SPEEXDSP_H_
+/** @hidden */
+#define _UPIPE_MODULES_UPIPE_SPEEXDSP_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <upipe/upipe.h>
+
+#define UPIPE_SPEEXDSP_SIGNATURE UBASE_FOURCC('s','p','x','d')
+
+/** @This returns the management structure for speexdsp pipes.
+ *
+ * @return pointer to manager
+ */
+struct upipe_mgr *upipe_speexdsp_mgr_alloc(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -36,6 +36,10 @@ if HAVE_SWRESAMPLE
 SUBDIRS += upipe-swresample
 endif
 
+if HAVE_SPEEXDSP
+SUBDIRS += upipe-speexdsp
+endif
+
 if HAVE_DLFCN_H
 SUBDIRS += upipe-blackmagic
 endif

--- a/lib/upipe-speexdsp/Makefile.am
+++ b/lib/upipe-speexdsp/Makefile.am
@@ -1,0 +1,10 @@
+lib_LTLIBRARIES = libupipe_speexdsp.la
+
+libupipe_speexdsp_la_SOURCES = upipe_speexdsp.c
+libupipe_speexdsp_la_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
+libupipe_speexdsp_la_CFLAGS = $(SPEEXDSP_CFLAGS)
+libupipe_speexdsp_la_LIBADD = $(SPEEXDSP_LIBS)
+libupipe_speexdsp_la_LDFLAGS = -no-undefined
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libupipe_speexdsp.pc

--- a/lib/upipe-speexdsp/libupipe_speexdsp.pc.in
+++ b/lib/upipe-speexdsp/libupipe_speexdsp.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+Name: libupipe_speexdsp
+Description: Upipe multimedia framework, speexdsp interface module
+Version: @VERSION@
+Requires: speexdsp libupipe
+Libs: -L${libdir} -lupipe_speexdsp
+Cflags: -I${includedir}

--- a/lib/upipe-speexdsp/upipe_speexdsp.c
+++ b/lib/upipe-speexdsp/upipe_speexdsp.c
@@ -1,0 +1,433 @@
+/*
+ * Copyright (C) 2016 Open Broadcast Systems Ltd
+ *
+ * Authors: Rafaël Carré
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/** @file
+ * @short Upipe speexdsp resampler module
+ */
+
+#include <upipe/ubase.h>
+#include <upipe/uprobe.h>
+#include <upipe/uref.h>
+#include <upipe/ubuf.h>
+#include <upipe/uref_clock.h>
+#include <upipe/uref_sound.h>
+#include <upipe/uref_sound_flow.h>
+#include <upipe/uref_dump.h>
+#include <upipe/uclock.h>
+#include <upipe/upipe.h>
+#include <upipe/upipe_helper_upipe.h>
+#include <upipe/upipe_helper_urefcount.h>
+#include <upipe/upipe_helper_void.h>
+#include <upipe/upipe_helper_flow_def.h>
+#include <upipe/upipe_helper_ubuf_mgr.h>
+#include <upipe/upipe_helper_output.h>
+#include <upipe/upipe_helper_input.h>
+
+#include <upipe-speexdsp/upipe_speexdsp.h>
+
+#include <speex/speex_resampler.h>
+
+/** @hidden */
+static bool upipe_speexdsp_handle(struct upipe *upipe, struct uref *uref,
+                             struct upump **upump_p);
+/** @hidden */
+static int upipe_speexdsp_check(struct upipe *upipe, struct uref *flow_format);
+
+/** upipe_speexdsp structure with speexdsp parameters */
+struct upipe_speexdsp {
+    /** refcount management structure */
+    struct urefcount urefcount;
+
+    /** input flow */
+    struct uref *flow_def_input;
+    /** attributes added by the pipe */
+    struct uref *flow_def_attr;
+    /** output flow */
+    struct uref *flow_def;
+    /** output state */
+    enum upipe_helper_output_state output_state;
+    /** list of output requests */
+    struct uchain request_list;
+    /** output pipe */
+    struct upipe *output;
+
+    /** ubuf manager */
+    struct ubuf_mgr *ubuf_mgr;
+    /** flow format packet */
+    struct uref *flow_format;
+    /** ubuf manager request */
+    struct urequest ubuf_mgr_request;
+
+    /** temporary uref storage (used during urequest) */
+    struct uchain urefs;
+    /** nb urefs in storage */
+    unsigned int nb_urefs;
+    /** max urefs in storage */
+    unsigned int max_urefs;
+    /** list of blockers (used during udeal) */
+    struct uchain blockers;
+
+    /** speexdsp context */
+    SpeexResamplerState *ctx;
+
+    /** float or int16_t */
+    bool f32;
+
+    /** sampling rate */
+    uint64_t rate;
+
+    /** current drift rate */
+    struct urational drift_rate;
+
+    /** public upipe structure */
+    struct upipe upipe;
+};
+
+UPIPE_HELPER_UPIPE(upipe_speexdsp, upipe, UPIPE_SPEEXDSP_SIGNATURE);
+UPIPE_HELPER_UREFCOUNT(upipe_speexdsp, urefcount, upipe_speexdsp_free);
+UPIPE_HELPER_VOID(upipe_speexdsp)
+UPIPE_HELPER_OUTPUT(upipe_speexdsp, output, flow_def, output_state, request_list)
+UPIPE_HELPER_FLOW_DEF(upipe_speexdsp, flow_def_input, flow_def_attr)
+UPIPE_HELPER_UBUF_MGR(upipe_speexdsp, ubuf_mgr, flow_format, ubuf_mgr_request,
+                      upipe_speexdsp_check,
+                      upipe_speexdsp_register_output_request,
+                      upipe_speexdsp_unregister_output_request)
+UPIPE_HELPER_INPUT(upipe_speexdsp, urefs, nb_urefs, max_urefs, blockers, upipe_speexdsp_handle)
+
+/** @internal @This handles data.
+ *
+ * @param upipe description structure of the pipe
+ * @param uref uref structure
+ * @param upump_p reference to pump that generated the buffer
+ * @return false if the input must be blocked
+ */
+static bool upipe_speexdsp_handle(struct upipe *upipe, struct uref *uref,
+                             struct upump **upump_p)
+{
+    struct upipe_speexdsp *upipe_speexdsp = upipe_speexdsp_from_upipe(upipe);
+
+    struct urational drift_rate;
+    if (!ubase_check(uref_clock_get_rate(uref, &drift_rate)))
+        drift_rate = (struct urational){ 1, 1 };
+
+    /* reinitialize resampler when drift rate changes */
+    if (urational_cmp(&drift_rate, &upipe_speexdsp->drift_rate)) {
+        upipe_speexdsp->drift_rate = drift_rate;
+        spx_uint32_t ratio_num = drift_rate.den;
+        spx_uint32_t ratio_den = drift_rate.num;
+        spx_uint32_t in_rate = upipe_speexdsp->rate * ratio_num / ratio_den;
+        spx_uint32_t out_rate = upipe_speexdsp->rate;
+        int err = speex_resampler_set_rate_frac(upipe_speexdsp->ctx,
+                ratio_num, ratio_den, in_rate, out_rate);
+        if (err) {
+            upipe_err_va(upipe, "Couldn't resample from %u to %u: %s",
+                in_rate, out_rate, speex_resampler_strerror(err));
+        } else {
+            upipe_dbg_va(upipe, "Resampling from %u to %u",
+                in_rate, out_rate);
+        }
+    }
+
+    size_t size;
+    if (!ubase_check(uref_sound_size(uref, &size, NULL /* sample_size */))) {
+        uref_free(uref);
+        return true;
+    }
+
+    struct ubuf *ubuf = ubuf_sound_alloc(uref->ubuf->mgr, size + 10);
+    if (!ubuf)
+        return false;
+
+    const void *in;
+    uref_sound_read_void(uref, 0, -1, &in, 1);
+
+    void *out;
+    ubuf_sound_write_void(ubuf, 0, -1, &out, 1);
+
+    spx_uint32_t in_len = size;         /* input size */
+    spx_uint32_t out_len = size + 10;   /* available output size */
+
+    int err;
+
+    if (upipe_speexdsp->f32)
+        err = speex_resampler_process_interleaved_float(upipe_speexdsp->ctx,
+                in, &in_len, out, &out_len);
+    else
+        err = speex_resampler_process_interleaved_int(upipe_speexdsp->ctx,
+                in, &in_len, out, &out_len);
+
+    if (err) {
+        upipe_err_va(upipe, "Could not resample: %s",
+                speex_resampler_strerror(err));
+    }
+
+    uref_sound_unmap(uref, 0, -1, 1);
+    ubuf_sound_unmap(ubuf, 0, -1, 1);
+
+    if (err) {
+        ubuf_free(ubuf);
+    } else {
+        ubuf_sound_resize(ubuf, 0, out_len);
+        uref_attach_ubuf(uref, ubuf);
+    }
+
+    upipe_speexdsp_output(upipe, uref, upump_p);
+    return true;
+}
+
+/** @internal @This receives incoming uref.
+ *
+ * @param upipe description structure of the pipe
+ * @param uref uref structure describing the picture
+ * @param upump_p reference to pump that generated the buffer
+ */
+static void upipe_speexdsp_input(struct upipe *upipe, struct uref *uref,
+                            struct upump **upump_p)
+{
+    if (!upipe_speexdsp_check_input(upipe)) {
+        upipe_speexdsp_hold_input(upipe, uref);
+        upipe_speexdsp_block_input(upipe, upump_p);
+    } else if (!upipe_speexdsp_handle(upipe, uref, upump_p)) {
+        upipe_speexdsp_hold_input(upipe, uref);
+        upipe_speexdsp_block_input(upipe, upump_p);
+        /* Increment upipe refcount to avoid disappearing before all packets
+         * have been sent. */
+        upipe_use(upipe);
+    }
+}
+
+/** @internal @This receives a provided ubuf manager.
+ *
+ * @param upipe description structure of the pipe
+ * @param flow_format amended flow format
+ * @return an error code
+ */
+static int upipe_speexdsp_check(struct upipe *upipe, struct uref *flow_format)
+{
+    struct upipe_speexdsp *upipe_speexdsp = upipe_speexdsp_from_upipe(upipe);
+    if (flow_format != NULL)
+        upipe_speexdsp_store_flow_def(upipe, flow_format);
+
+    if (upipe_speexdsp->flow_def == NULL)
+        return UBASE_ERR_NONE;
+
+    bool was_buffered = !upipe_speexdsp_check_input(upipe);
+    upipe_speexdsp_output_input(upipe);
+    upipe_speexdsp_unblock_input(upipe);
+    if (was_buffered && upipe_speexdsp_check_input(upipe)) {
+        /* All packets have been output, release again the pipe that has been
+         * used in @ref upipe_speexdsp_input. */
+        upipe_release(upipe);
+    }
+    return UBASE_ERR_NONE;
+}
+
+/** @internal @This sets the input flow definition.
+ *
+ * @param upipe description structure of the pipe
+ * @param flow_def flow definition packet
+ * @return an error code
+ */
+static int upipe_speexdsp_set_flow_def(struct upipe *upipe, struct uref *flow_def)
+{
+    struct upipe_speexdsp *upipe_speexdsp = upipe_speexdsp_from_upipe(upipe);
+
+    if (flow_def == NULL)
+        return UBASE_ERR_INVALID;
+
+    const char *def;
+    UBASE_RETURN(uref_flow_get_def(flow_def, &def))
+
+    if (unlikely(ubase_ncmp(def, "sound.f32.") &&
+                ubase_ncmp(def, "sound.s16.")))
+        return UBASE_ERR_INVALID;
+
+    uint8_t in_planes;
+    if (unlikely(!ubase_check(uref_sound_flow_get_planes(flow_def,
+                                                         &in_planes))))
+        return UBASE_ERR_INVALID;
+
+    if (in_planes != 1) {
+        upipe_err(upipe, "only interleaved audio is supported");
+        return UBASE_ERR_INVALID;
+    }
+
+    if (!ubase_check(uref_sound_flow_get_rate(flow_def,
+                    &upipe_speexdsp->rate))) {
+        upipe_err(upipe, "no sound rate defined");
+        uref_dump(flow_def, upipe->uprobe);
+        return UBASE_ERR_INVALID;
+    }
+
+    uint8_t channels;
+    if (unlikely(!ubase_check(uref_sound_flow_get_channels(flow_def,
+                        &channels))))
+        return UBASE_ERR_INVALID;
+
+    flow_def = uref_dup(flow_def);
+    if (unlikely(flow_def == NULL)) {
+        upipe_throw_fatal(upipe, UBASE_ERR_ALLOC);
+        return UBASE_ERR_ALLOC;
+    }
+
+    upipe_speexdsp_store_flow_def(upipe, flow_def);
+
+    if (upipe_speexdsp->ctx)
+        speex_resampler_destroy(upipe_speexdsp->ctx);
+
+    upipe_speexdsp->f32 = !ubase_ncmp(def, "sound.f32.");
+
+    int err;
+    upipe_speexdsp->ctx = speex_resampler_init(channels,
+                upipe_speexdsp->rate, upipe_speexdsp->rate,
+                SPEEX_RESAMPLER_QUALITY_MAX, &err);
+    if (!upipe_speexdsp->ctx) {
+        upipe_err_va(upipe, "Could not create resampler: %s",
+                speex_resampler_strerror(err));
+        return UBASE_ERR_INVALID;
+    }
+
+    return UBASE_ERR_NONE;
+}
+
+/** @internal @This processes control commands on a speexdsp pipe.
+ *
+ * @param upipe description structure of the pipe
+ * @param command type of command to process
+ * @param args arguments of the command
+ * @return an error code
+ */
+static int upipe_speexdsp_control(struct upipe *upipe, int command, va_list args)
+{
+    switch (command) {
+        /* generic commands */
+        case UPIPE_REGISTER_REQUEST: {
+            struct urequest *request = va_arg(args, struct urequest *);
+            if (request->type == UREQUEST_UBUF_MGR ||
+                request->type == UREQUEST_FLOW_FORMAT)
+                return upipe_throw_provide_request(upipe, request);
+            return upipe_speexdsp_alloc_output_proxy(upipe, request);
+        }
+        case UPIPE_UNREGISTER_REQUEST: {
+            struct urequest *request = va_arg(args, struct urequest *);
+            if (request->type == UREQUEST_UBUF_MGR ||
+                request->type == UREQUEST_FLOW_FORMAT)
+                return UBASE_ERR_NONE;
+            return upipe_speexdsp_free_output_proxy(upipe, request);
+        }
+
+        case UPIPE_GET_OUTPUT: {
+            struct upipe **p = va_arg(args, struct upipe **);
+            return upipe_speexdsp_get_output(upipe, p);
+        }
+        case UPIPE_SET_OUTPUT: {
+            struct upipe *output = va_arg(args, struct upipe *);
+            return upipe_speexdsp_set_output(upipe, output);
+        }
+        case UPIPE_GET_FLOW_DEF: {
+            struct uref **p = va_arg(args, struct uref **);
+            return upipe_speexdsp_get_flow_def(upipe, p);
+        }
+        case UPIPE_SET_FLOW_DEF: {
+            struct uref *flow = va_arg(args, struct uref *);
+            return upipe_speexdsp_set_flow_def(upipe, flow);
+        }
+
+        default:
+            return UBASE_ERR_UNHANDLED;
+    }
+}
+
+/** @internal @This allocates a speexdsp pipe.
+ *
+ * @param mgr common management structure
+ * @param uprobe structure used to raise events
+ * @param signature signature of the pipe allocator
+ * @param args optional arguments
+ * @return pointer to upipe or NULL in case of allocation error
+ */
+static struct upipe *upipe_speexdsp_alloc(struct upipe_mgr *mgr,
+                                     struct uprobe *uprobe,
+                                     uint32_t signature, va_list args)
+{
+    struct upipe *upipe = upipe_speexdsp_alloc_void(mgr, uprobe, signature,
+                                               args);
+    if (unlikely(upipe == NULL))
+        return NULL;
+
+    struct upipe_speexdsp *upipe_speexdsp = upipe_speexdsp_from_upipe(upipe);
+
+    upipe_speexdsp->ctx = NULL;
+    upipe_speexdsp->drift_rate = (struct urational){ 0, 0 };
+
+    upipe_speexdsp_init_urefcount(upipe);
+    upipe_speexdsp_init_ubuf_mgr(upipe);
+    upipe_speexdsp_init_output(upipe);
+    upipe_speexdsp_init_flow_def(upipe);
+    upipe_speexdsp_init_input(upipe);
+
+    upipe_throw_ready(upipe);
+    return upipe;
+}
+
+/** @This frees a upipe.
+ *
+ * @param upipe description structure of the pipe
+ */
+static void upipe_speexdsp_free(struct upipe *upipe)
+{
+    struct upipe_speexdsp *upipe_speexdsp = upipe_speexdsp_from_upipe(upipe);
+    if (likely(upipe_speexdsp->ctx))
+        speex_resampler_destroy(upipe_speexdsp->ctx);
+
+    upipe_throw_dead(upipe);
+    upipe_speexdsp_clean_input(upipe);
+    upipe_speexdsp_clean_output(upipe);
+    upipe_speexdsp_clean_flow_def(upipe);
+    upipe_speexdsp_clean_ubuf_mgr(upipe);
+    upipe_speexdsp_clean_urefcount(upipe);
+    upipe_speexdsp_free_void(upipe);
+}
+
+/** module manager static descriptor */
+static struct upipe_mgr upipe_speexdsp_mgr = {
+    .refcount = NULL,
+    .signature = UPIPE_SPEEXDSP_SIGNATURE,
+
+    .upipe_alloc = upipe_speexdsp_alloc,
+    .upipe_input = upipe_speexdsp_input,
+    .upipe_control = upipe_speexdsp_control,
+
+    .upipe_mgr_control = NULL
+};
+
+/** @This returns the management structure for speexdsp pipes
+ *
+ * @return pointer to manager
+ */
+struct upipe_mgr *upipe_speexdsp_mgr_alloc(void)
+{
+    return &upipe_speexdsp_mgr;
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -96,6 +96,7 @@ check_PROGRAMS = \
 	upipe_filter_ebur128_test \
 	upipe_audio_max_test \
 	upipe_audio_bar_test \
+    upipe_speexdsp_test \
 	upipe_filter_blend_test
 
 TESTS = \
@@ -150,6 +151,13 @@ TESTS = \
 	upipe_audio_max_test \
 	upipe_audio_bar_test \
 	upipe_filter_blend_test
+
+if HAVE_SPEEXDSP
+check_PROGRAMS += \
+    upipe_speexdsp_test
+TESTS += \
+    upipe_speexdsp_test
+endif
 
 if HAVE_EV
 check_PROGRAMS += \
@@ -415,6 +423,7 @@ upipe_filter_blend_test_LDADD = $(LDADD) $(top_builddir)/lib/upipe-filters/libup
 upipe_filter_ebur128_test_LDADD = $(LDADD) -lm $(top_builddir)/lib/upipe-filters/libupipe_filters.la $(top_builddir)/lib/upipe-modules/libupipe_modules.la
 upipe_audio_max_test_LDADD = $(LDADD) -lm $(top_builddir)/lib/upipe-filters/libupipe_filters.la $(top_builddir)/lib/upipe-modules/libupipe_modules.la
 upipe_audio_bar_test_LDADD = $(LDADD) -lm $(top_builddir)/lib/upipe-filters/libupipe_filters.la $(top_builddir)/lib/upipe-modules/libupipe_modules.la
+upipe_speexdsp_test_LDADD = $(LDADD) $(top_builddir)/lib/upipe-speexdsp/libupipe_speexdsp.la $(top_builddir)/lib/upipe-modules/libupipe_modules.la
 
 upipe_x264_test_LDADD = $(LDADD) $(X264_LIBS) $(top_builddir)/lib/upipe-x264/libupipe_x264.la
 upipe_x264_test_CFLAGS = $(X264_CFLAGS)

--- a/tests/upipe_speexdsp_test.c
+++ b/tests/upipe_speexdsp_test.c
@@ -108,7 +108,15 @@ static int test_control(struct upipe *upipe, int command, va_list args)
     switch (command) {
         case UPIPE_SET_FLOW_DEF:
             return UBASE_ERR_NONE;
+        case UPIPE_REGISTER_REQUEST: {
+            struct urequest *urequest = va_arg(args, struct urequest *);
+            return upipe_throw_provide_request(upipe, urequest);
+        }
+        case UPIPE_UNREGISTER_REQUEST:
+            return UBASE_ERR_NONE;
         default:
+            upipe_err_va(upipe, "unhandled command %s",
+                    upipe_command_str(upipe, command));
             assert(0);
             return UBASE_ERR_UNHANDLED;
     }

--- a/tests/upipe_speexdsp_test.c
+++ b/tests/upipe_speexdsp_test.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2016 Open Broadcast Systems Ltd
+ *
+ * Authors: Rafaël Carré
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#undef NDEBUG
+
+#include <upipe/uprobe.h>
+#include <upipe/uprobe_stdio.h>
+#include <upipe/uprobe_prefix.h>
+#include <upipe/uprobe_ubuf_mem.h>
+#include <upipe/uclock.h>
+#include <upipe/umem.h>
+#include <upipe/umem_alloc.h>
+#include <upipe/udict.h>
+#include <upipe/udict_inline.h>
+#include <upipe/uref.h>
+#include <upipe/uref_std.h>
+#include <upipe/uref_sound.h>
+#include <upipe/uref_sound_flow.h>
+#include <upipe/uref_clock.h>
+#include <upipe/uref_dump.h>
+#include <upipe/upipe.h>
+#include <upipe/ubuf_sound_mem.h>
+
+#include <upipe-speexdsp/upipe_speexdsp.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <math.h>
+#include <assert.h>
+
+#define UDICT_POOL_DEPTH    5
+#define UREF_POOL_DEPTH     5
+#define UBUF_POOL_DEPTH     0
+#define SAMPLES             1024
+#define UPROBE_LOG_LEVEL    UPROBE_LOG_VERBOSE
+#define ALIGN               0
+
+static bool got_input = false;
+
+/** definition of our uprobe */
+static int catch(struct uprobe *uprobe, struct upipe *upipe,
+                 int event, va_list args)
+{
+    switch (event) {
+        case UPROBE_READY:
+        case UPROBE_DEAD:
+        case UPROBE_NEW_FLOW_DEF:
+            break;
+        default:
+            assert(0);
+            break;
+    }
+    return UBASE_ERR_NONE;
+}
+
+/** helper phony pipe */
+static struct upipe *test_alloc(struct upipe_mgr *mgr, struct uprobe *uprobe,
+                                uint32_t signature, va_list args)
+{
+    struct upipe *upipe = malloc(sizeof(struct upipe));
+	upipe_init(upipe, mgr, uprobe);
+    upipe_throw_ready(upipe);
+    return upipe;
+}
+
+/** helper phony pipe */
+static void test_input(struct upipe *upipe, struct uref *uref,
+                       struct upump **upump_p)
+{
+    assert(uref != NULL);
+    upipe_dbg(upipe, "===> received input uref");
+    size_t size;
+    ubase_assert(uref_sound_size(uref, &size, NULL));
+    assert(size == SAMPLES+1);
+    uref_dump(uref, upipe->uprobe);
+    uref_free(uref);
+    got_input = true;
+}
+
+/** helper phony pipe */
+static int test_control(struct upipe *upipe, int command, va_list args)
+{
+    switch (command) {
+        case UPIPE_SET_FLOW_DEF:
+            return UBASE_ERR_NONE;
+        default:
+            assert(0);
+            return UBASE_ERR_UNHANDLED;
+    }
+}
+
+/** helper phony pipe */
+static void test_free(struct upipe *upipe)
+{
+    upipe_dbg(upipe, "releasing pipe");
+    upipe_throw_dead(upipe);
+    upipe_clean(upipe);
+    free(upipe);
+}
+
+/** helper phony pipe */
+static struct upipe_mgr test_mgr = {
+    .refcount = NULL,
+    .signature = 0,
+    .upipe_alloc = test_alloc,
+    .upipe_input = test_input,
+    .upipe_control = test_control
+};
+
+static void fill_in(struct ubuf *ubuf)
+{
+    size_t size;
+    uint8_t sample_size;
+    ubase_assert(ubuf_sound_size(ubuf, &size, &sample_size));
+
+    const char *channel = NULL;
+    int16_t v = 0;
+    while (ubase_check(ubuf_sound_plane_iterate(ubuf, &channel)) &&
+           channel != NULL) {
+        int16_t *buffer;
+        ubase_assert(ubuf_sound_plane_write_int16_t(ubuf, channel, 0, -1,
+                                                    &buffer));
+
+        for (int x = 0; x < size; x++) {
+            buffer[2*x+0] = v++;
+            buffer[2*x+1] = v++;
+        }
+        ubase_assert(ubuf_sound_plane_unmap(ubuf, channel, 0, -1));
+    }
+}
+
+int main(int argc, char **argv)
+{
+    printf("Compiled %s %s - %s\n", __DATE__, __TIME__, __FILE__);
+    int i, j, k;
+
+    /* uref and mem management */
+    struct umem_mgr *umem_mgr = umem_alloc_mgr_alloc();
+    assert(umem_mgr != NULL);
+    struct udict_mgr *udict_mgr = udict_inline_mgr_alloc(UDICT_POOL_DEPTH,
+                                                         umem_mgr, -1, -1);
+    assert(udict_mgr != NULL);
+    struct uref_mgr *uref_mgr = uref_std_mgr_alloc(UREF_POOL_DEPTH,
+                                                   udict_mgr, 0);
+    assert(uref_mgr != NULL);
+
+    /* sound */
+    struct ubuf_mgr *sound_mgr = ubuf_sound_mem_mgr_alloc(UBUF_POOL_DEPTH,
+                                             UBUF_POOL_DEPTH, umem_mgr, 2*2, ALIGN);
+    assert(sound_mgr);
+    ubase_assert(ubuf_sound_mem_mgr_add_plane(sound_mgr, "lr"));
+
+    /* uprobe stuff */
+    struct uprobe uprobe;
+    uprobe_init(&uprobe, catch, NULL);
+    struct uprobe *logger = uprobe_stdio_alloc(&uprobe, stdout,
+                                               UPROBE_LOG_LEVEL);
+    assert(logger != NULL);
+    logger = uprobe_ubuf_mem_alloc(logger, umem_mgr, UBUF_POOL_DEPTH,
+                                                     UBUF_POOL_DEPTH);
+    assert(logger != NULL);
+
+    /* build speexdsp pipe */
+    struct upipe_mgr *upipe_speexdsp_mgr = upipe_speexdsp_mgr_alloc();
+    assert(upipe_speexdsp_mgr);
+    struct upipe *speexdsp = upipe_void_alloc(upipe_speexdsp_mgr,
+        uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL, "speexdsp"));
+    assert(speexdsp);
+
+    /* build phony pipe */
+    struct upipe *test = upipe_void_alloc(&test_mgr,
+            uprobe_pfx_alloc(uprobe_use(logger), UPROBE_LOG_LEVEL,
+                             "test"));
+    assert(test != NULL);
+    ubase_assert(upipe_set_output(speexdsp, test));
+
+    struct uref *flow_def =
+        uref_sound_flow_alloc_def(uref_mgr, "s16.", 2, 2 * 2);
+    ubase_assert(uref_sound_flow_add_plane(flow_def, "lr"));
+    ubase_assert(uref_sound_flow_set_rate(flow_def, 48000));
+    ubase_assert(upipe_set_flow_def(speexdsp, flow_def));
+    uref_free(flow_def);
+
+    struct uref *uref = uref_sound_alloc(uref_mgr, sound_mgr, SAMPLES);
+    fill_in(uref->ubuf);
+    struct urational drift = {
+        .num = SAMPLES+1,
+        .den = SAMPLES,
+    };
+    uref_clock_set_rate(uref, drift);
+    upipe_input(speexdsp, uref, NULL);
+    assert(got_input);
+
+    /* release pipe */
+    upipe_release(speexdsp);
+    test_free(test);
+
+    /* release managers */
+    upipe_mgr_release(upipe_speexdsp_mgr); // no-op
+    ubuf_mgr_release(sound_mgr);
+    uref_mgr_release(uref_mgr);
+    umem_mgr_release(umem_mgr);
+    udict_mgr_release(udict_mgr);
+    uprobe_release(logger);
+    uprobe_clean(&uprobe);
+
+    return 0;
+}


### PR DESCRIPTION
A few things that could be improved:
- make quality configurable (max quality is ok on CPU)
- use that module to resample at a fixed configurable rate (like swr for example), although not sure how to have the 2 modes.