### PR TITLE
bi-directional udp

### DIFF
--- a/examples/mpthree2rtp.c
+++ b/examples/mpthree2rtp.c
@@ -255,7 +255,7 @@ int main(int argc, char **argv)
     upipe = upipe_void_chain_output(upipe, udp_mgr,
         uprobe_pfx_alloc(uprobe_use(mainprobe), UPROBE_LOG_VERBOSE, "udp"));
     upipe_attach_uclock(upipe);
-    ubase_assert(upipe_udpsink_set_uri(upipe, duri, 0));
+    ubase_assert(upipe_set_uri(upipe, duri));
     upipe_release(upipe);
 
     upipe_mgr_release(fsrc_mgr);

--- a/examples/udpmulticat.c
+++ b/examples/udpmulticat.c
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
                 upipe_udpsink_mgr,
                 uprobe_pfx_alloc(uprobe_use(logger),
                                  loglevel, "udpsink"));
-        if (!ubase_check(upipe_udpsink_set_uri(upipe_sink, dirpath, 0))) {
+        if (!ubase_check(upipe_set_uri(upipe_sink, dirpath))) {
             return EXIT_FAILURE;
         }
         upipe_release(upipe_sink);

--- a/include/upipe-modules/upipe_udp_sink.h
+++ b/include/upipe-modules/upipe_udp_sink.h
@@ -52,7 +52,11 @@ enum upipe_udpsink_command {
     /** returns the uri of the currently opened udp (const char **) */
     UPIPE_UDPSINK_GET_URI,
     /** asks to open the given uri (const char *, enum upipe_udpsink_mode) */
-    UPIPE_UDPSINK_SET_URI
+    UPIPE_UDPSINK_SET_URI,
+    /** get socket fd (int*) **/
+    UPIPE_UDPSINK_GET_FD,
+    /** set socket fd (int) **/
+    UPIPE_UDPSINK_SET_FD,
 };
 
 /** @This returns the management structure for all udp sinks.
@@ -60,6 +64,30 @@ enum upipe_udpsink_command {
  * @return pointer to manager
  */
 struct upipe_mgr *upipe_udpsink_mgr_alloc(void);
+
+/** @This returns currently opened udp fd.
+ *
+ * @param upipe description structure of the pipe
+ * @param fd_p filled in with the fd of the udp
+ * @return false in case of error
+ */
+static inline int upipe_udpsink_get_fd(struct upipe *upipe, int *fd_p)
+{
+    return upipe_control(upipe, UPIPE_UDPSINK_GET_FD, UPIPE_UDPSINK_SIGNATURE,
+                         fd_p);
+}
+
+/** @This sets the udp fd.
+ *
+ * @param upipe description structure of the pipe
+ * @param fd file descriptor
+ * @return false in case of error
+ */
+static inline int upipe_udpsink_set_fd(struct upipe *upipe, int fd)
+{
+    return upipe_control(upipe, UPIPE_UDPSINK_SET_FD, UPIPE_UDPSINK_SIGNATURE,
+                         fd);
+}
 
 /** @This returns the uri of the currently opened udp uri.
  *

--- a/include/upipe-modules/upipe_udp_sink.h
+++ b/include/upipe-modules/upipe_udp_sink.h
@@ -36,6 +36,8 @@ extern "C" {
 #endif
 
 #include <upipe/upipe.h>
+#include <sys/types.h>
+#include <sys/socket.h>
 
 #define UPIPE_UDPSINK_SIGNATURE UBASE_FOURCC('u','s','n','k')
 
@@ -47,6 +49,8 @@ enum upipe_udpsink_command {
     UPIPE_UDPSINK_GET_FD,
     /** set socket fd (int) **/
     UPIPE_UDPSINK_SET_FD,
+    /** set remote address (const struct sockaddr *, socklen_t) **/
+    UPIPE_UDPSINK_SET_PEER,
 };
 
 /** @This returns the management structure for all udp sinks.
@@ -79,6 +83,19 @@ static inline int upipe_udpsink_set_fd(struct upipe *upipe, int fd)
                          fd);
 }
 
+/** @This sets the remote address (for unconnected sockets).
+ *
+ * @param upipe description structure of the pipe
+ * @param addr the remote address
+ * @param addrlen the size of addr
+ * @return false in case of error
+ */
+static inline int upipe_udpsink_set_peer(struct upipe *upipe,
+        const struct sockaddr *addr, socklen_t addrlen)
+{
+    return upipe_control(upipe, UPIPE_UDPSINK_SET_PEER, UPIPE_UDPSINK_SIGNATURE,
+            addr, addrlen);
+}
 #ifdef __cplusplus
 }
 #endif

--- a/include/upipe-modules/upipe_udp_sink.h
+++ b/include/upipe-modules/upipe_udp_sink.h
@@ -39,20 +39,10 @@ extern "C" {
 
 #define UPIPE_UDPSINK_SIGNATURE UBASE_FOURCC('u','s','n','k')
 
-/** @This defines udp opening modes. */
-enum upipe_udpsink_mode {
-    /** do not do anything besides opening the fd */
-    UPIPE_UDPSINK_NONE = 0,
-};
-
 /** @This extends upipe_command with specific commands for udp sink. */
 enum upipe_udpsink_command {
     UPIPE_UDPSINK_SENTINEL = UPIPE_CONTROL_LOCAL,
 
-    /** returns the uri of the currently opened udp (const char **) */
-    UPIPE_UDPSINK_GET_URI,
-    /** asks to open the given uri (const char *, enum upipe_udpsink_mode) */
-    UPIPE_UDPSINK_SET_URI,
     /** get socket fd (int*) **/
     UPIPE_UDPSINK_GET_FD,
     /** set socket fd (int) **/
@@ -87,34 +77,6 @@ static inline int upipe_udpsink_set_fd(struct upipe *upipe, int fd)
 {
     return upipe_control(upipe, UPIPE_UDPSINK_SET_FD, UPIPE_UDPSINK_SIGNATURE,
                          fd);
-}
-
-/** @This returns the uri of the currently opened udp uri.
- *
- * @param upipe description structure of the pipe
- * @param uri_p filled in with the uri of the udp
- * @return false in case of error
- */
-static inline int upipe_udpsink_get_uri(struct upipe *upipe,
-                                        const char **uri_p)
-{
-    return upipe_control(upipe, UPIPE_UDPSINK_GET_URI, UPIPE_UDPSINK_SIGNATURE,
-                         uri_p);
-}
-
-/** @This asks to open the given udp uri.
- *
- * @param upipe description structure of the pipe
- * @param uri relative or absolute uri
- * @param mode mode of opening the uri
- * @return false in case of error
- */
-static inline int upipe_udpsink_set_uri(struct upipe *upipe,
-                                        const char *uri,
-                                        enum upipe_udpsink_mode mode)
-{
-    return upipe_control(upipe, UPIPE_UDPSINK_SET_URI, UPIPE_UDPSINK_SIGNATURE,
-                         uri, mode);
 }
 
 #ifdef __cplusplus

--- a/include/upipe-modules/upipe_udp_source.h
+++ b/include/upipe-modules/upipe_udp_source.h
@@ -39,6 +39,40 @@ extern "C" {
 
 #define UPIPE_UDPSRC_SIGNATURE UBASE_FOURCC('u','s','r','c')
 
+/** @This extends upipe_command with specific commands. */
+enum upipe_udpsrc_command {
+    UPIPE_UDPSRC_SENTINEL = UPIPE_CONTROL_LOCAL,
+
+    /** get socket fd (int*) **/
+    UPIPE_UDPSRC_GET_FD,
+    /** set socket fd (int) **/
+    UPIPE_UDPSRC_SET_FD,
+};
+
+/** @This returns currently opened udp fd.
+ *
+ * @param upipe description structure of the pipe
+ * @param fd_p filled in with the fd of the udp
+ * @return false in case of error
+ */
+static inline int upipe_udpsrc_get_fd(struct upipe *upipe, int *fd_p)
+{
+    return upipe_control(upipe, UPIPE_UDPSRC_GET_FD, UPIPE_UDPSRC_SIGNATURE,
+                         fd_p);
+}
+
+/** @This sets the udp fd.
+ *
+ * @param upipe description structure of the pipe
+ * @param fd file descriptor
+ * @return false in case of error
+ */
+static inline int upipe_udpsrc_set_fd(struct upipe *upipe, int fd)
+{
+    return upipe_control(upipe, UPIPE_UDPSRC_SET_FD, UPIPE_UDPSRC_SIGNATURE,
+                         fd);
+}
+
 /** @This returns the management structure for all udp socket sources.
  *
  * @return pointer to manager

--- a/include/upipe-modules/upipe_udp_source.h
+++ b/include/upipe-modules/upipe_udp_source.h
@@ -49,6 +49,14 @@ enum upipe_udpsrc_command {
     UPIPE_UDPSRC_SET_FD,
 };
 
+/** @This extends uprobe_throw with specific events . */
+enum uprobe_udpsrc_event {
+    UPROBE_UDPSRC_SENTINEL = UPROBE_LOCAL,
+
+    /** remote address changed (const struct sockaddr*, socklen_t) **/
+    UPROBE_UDPSRC_NEW_PEER,
+};
+
 /** @This returns currently opened udp fd.
  *
  * @param upipe description structure of the pipe

--- a/lib/upipe-modules/upipe_udp_sink.c
+++ b/lib/upipe-modules/upipe_udp_sink.c
@@ -469,6 +469,8 @@ static int upipe_udpsink_flush(struct upipe *upipe)
 static int _upipe_udpsink_control(struct upipe *upipe,
                                   int command, va_list args)
 {
+    struct upipe_udpsink *upipe_udpsink = upipe_udpsink_from_upipe(upipe);
+
     switch (command) {
         case UPIPE_ATTACH_UPUMP_MGR:
             upipe_udpsink_set_upump(upipe, NULL);
@@ -516,6 +518,18 @@ static int _upipe_udpsink_control(struct upipe *upipe,
             const char *uri = va_arg(args, const char *);
             enum upipe_udpsink_mode mode = va_arg(args, enum upipe_udpsink_mode);
             return _upipe_udpsink_set_uri(upipe, uri, mode);
+        }
+        case UPIPE_UDPSINK_GET_FD: {
+            UBASE_SIGNATURE_CHECK(args, UPIPE_UDPSINK_SIGNATURE)
+            int *fd = va_arg(args, int *);
+            *fd = upipe_udpsink->fd;
+            return UBASE_ERR_NONE;
+        }
+        case UPIPE_UDPSINK_SET_FD: {
+            UBASE_SIGNATURE_CHECK(args, UPIPE_UDPSINK_SIGNATURE)
+            upipe_udpsink_set_upump(upipe, NULL);
+            upipe_udpsink->fd = va_arg(args, int );
+            return UBASE_ERR_NONE;
         }
         case UPIPE_FLUSH:
             return upipe_udpsink_flush(upipe);

--- a/lib/upipe-modules/upipe_udp_source.c
+++ b/lib/upipe-modules/upipe_udp_source.c
@@ -117,6 +117,11 @@ struct upipe_udpsrc {
     /** udp socket uri */
     char *uri;
 
+    /** source address */
+    struct sockaddr_storage addr;
+    /** source address (size) */
+    socklen_t addrlen;
+
     /** public upipe structure */
     struct upipe upipe;
 };
@@ -166,6 +171,7 @@ static struct upipe *upipe_udpsrc_alloc(struct upipe_mgr *mgr,
     upipe_udpsrc_init_output_size(upipe, UBUF_DEFAULT_SIZE);
     upipe_udpsrc->fd = -1;
     upipe_udpsrc->uri = NULL;
+    upipe_udpsrc->addrlen = 0;
     upipe_throw_ready(upipe);
     return upipe;
 }
@@ -202,7 +208,11 @@ static void upipe_udpsrc_worker(struct upump *upump)
     }
     assert(output_size == upipe_udpsrc->output_size);
 
-    ssize_t ret = read(upipe_udpsrc->fd, buffer, upipe_udpsrc->output_size);
+    struct sockaddr_storage addr;
+    socklen_t addrlen = sizeof(addr);
+
+    ssize_t ret = recvfrom(upipe_udpsrc->fd, buffer, upipe_udpsrc->output_size,
+                        0, (struct sockaddr*)&addr, &addrlen);
     uref_block_unmap(uref, 0);
 
     if (unlikely(ret == -1)) {
@@ -225,7 +235,14 @@ static void upipe_udpsrc_worker(struct upump *upump)
         upipe_udpsrc_set_upump(upipe, NULL);
         upipe_throw_source_end(upipe);
         return;
+    } else if (addrlen != upipe_udpsrc->addrlen ||
+        memcmp(&addr, &upipe_udpsrc->addr, addrlen)) {
+        upipe_throw(upipe, UPROBE_UDPSRC_NEW_PEER, UPIPE_UDPSRC_SIGNATURE,
+                &addr, &addrlen);
+        upipe_udpsrc->addrlen = addrlen;
+        memcpy(&upipe_udpsrc->addr, &addr, addrlen);
     }
+
     if (unlikely(ret == 0)) {
         uref_free(uref);
         if (likely(upipe_udpsrc->uclock == NULL)) {

--- a/lib/upipe-modules/upipe_udp_source.c
+++ b/lib/upipe-modules/upipe_udp_source.c
@@ -359,6 +359,8 @@ static int upipe_udpsrc_set_uri(struct upipe *upipe, const char *uri)
 static int _upipe_udpsrc_control(struct upipe *upipe,
                                  int command, va_list args)
 {
+    struct upipe_udpsrc *upipe_udpsrc = upipe_udpsrc_from_upipe(upipe);
+
     switch (command) {
         case UPIPE_ATTACH_UPUMP_MGR:
             upipe_udpsrc_set_upump(upipe, NULL);
@@ -397,6 +399,18 @@ static int _upipe_udpsrc_control(struct upipe *upipe,
         case UPIPE_SET_URI: {
             const char *uri = va_arg(args, const char *);
             return upipe_udpsrc_set_uri(upipe, uri);
+        }
+        case UPIPE_UDPSRC_GET_FD: {
+            UBASE_SIGNATURE_CHECK(args, UPIPE_UDPSRC_SIGNATURE)
+            int *fd = va_arg(args, int *);
+            *fd = upipe_udpsrc->fd;
+            return UBASE_ERR_NONE;
+        }
+        case UPIPE_UDPSRC_SET_FD: {
+            UBASE_SIGNATURE_CHECK(args, UPIPE_UDPSRC_SIGNATURE)
+            upipe_udpsrc_set_upump(upipe, NULL);
+            upipe_udpsrc->fd = va_arg(args, int );
+            return UBASE_ERR_NONE;
         }
         default:
             return UBASE_ERR_UNHANDLED;

--- a/tests/upipe_udp_test.c
+++ b/tests/upipe_udp_test.c
@@ -363,7 +363,7 @@ int main(int argc, char *argv[])
         }
     }
     assert(ret);
-    ubase_assert(upipe_udpsink_set_uri(upipe_udpsink, udp_uri+1, 0));
+    ubase_assert(upipe_set_uri(upipe_udpsink, udp_uri+1));
 
     /* redefine write pump */
     write_pump = upump_alloc_idler(upump_mgr, genpackets2, NULL, NULL);

--- a/tests/upipe_udp_test.c
+++ b/tests/upipe_udp_test.c
@@ -117,6 +117,7 @@ static int catch(struct uprobe *uprobe, struct upipe *upipe,
         case UPROBE_DEAD:
         case UPROBE_NEW_FLOW_DEF:
         case UPROBE_SOURCE_END:
+        case UPROBE_UDPSRC_NEW_PEER:
             break;
     }
     return UBASE_ERR_NONE;


### PR DESCRIPTION
These commits let us do bi-directional UDP for NAT traversal

We can detect source address changes on udpsrc, give the udpsrc (which used bind()) fd to udpsink,
and set the remote peer address of udpsink.