### PR TITLE
ubuf_block: fix 220fc2e5

### DIFF
--- a/include/upipe/ubuf_block.h
+++ b/include/upipe/ubuf_block.h
@@ -280,6 +280,7 @@ static inline int ubuf_block_append(struct ubuf *ubuf, struct ubuf *append)
         return UBASE_ERR_INVALID;
 
     struct ubuf_block *block = ubuf_block_from_ubuf(ubuf);
+    struct ubuf_block *head_block = block;
     struct ubuf_block *append_block = ubuf_block_from_ubuf(append);
     block->total_size += append_block->total_size;
 
@@ -292,6 +293,7 @@ static inline int ubuf_block_append(struct ubuf *ubuf, struct ubuf *append)
         block = ubuf_block_from_ubuf(ubuf);
     }
     block->next_ubuf = append;
+    head_block->cached_end_ubuf = append;
     return UBASE_ERR_NONE;
 }
 


### PR DESCRIPTION
This hunk was missed when sending Kieran's code.

This removes the slowness in h264 framer.

However since the code has changed since, please review and make sure it won't cause additional side effects.

ihavenoideawhatiamdoing.jpg