### PR TITLE
ts-demux: initialize upipe_mgr

### DIFF
--- a/lib/upipe-ts/upipe_ts_demux.c
+++ b/lib/upipe-ts/upipe_ts_demux.c
@@ -1126,6 +1126,9 @@ static void upipe_ts_demux_program_init_output_mgr(struct upipe *upipe)
     struct upipe_mgr *output_mgr = &program->output_mgr;
     output_mgr->refcount = upipe_ts_demux_program_to_urefcount_real(program);
     output_mgr->signature = UPIPE_TS_DEMUX_OUTPUT_SIGNATURE;
+    output_mgr->upipe_err_str = NULL;
+    output_mgr->upipe_command_str = NULL;
+    output_mgr->upipe_event_str = NULL;
     output_mgr->upipe_alloc = upipe_ts_demux_output_alloc;
     output_mgr->upipe_input = NULL;
     output_mgr->upipe_control = upipe_ts_demux_output_control;
@@ -1813,6 +1816,9 @@ static void upipe_ts_demux_init_program_mgr(struct upipe *upipe)
     struct upipe_mgr *program_mgr = &upipe_ts_demux->program_mgr;
     program_mgr->refcount = upipe_ts_demux_to_urefcount_real(upipe_ts_demux);
     program_mgr->signature = UPIPE_TS_DEMUX_PROGRAM_SIGNATURE;
+    program_mgr->upipe_err_str = NULL;
+    program_mgr->upipe_command_str = NULL;
+    program_mgr->upipe_event_str = NULL;
     program_mgr->upipe_alloc = upipe_ts_demux_program_alloc;
     program_mgr->upipe_input = NULL;
     program_mgr->upipe_control = upipe_ts_demux_program_control;


### PR DESCRIPTION
upipe_{err,command,event}_str were uninitialized
This could cause a crash when sending them an unknown command