### PR TITLE
Urefcount

### DIFF
--- a/include/upipe/upipe.h
+++ b/include/upipe/upipe.h
@@ -461,17 +461,6 @@ static inline bool upipe_single(struct upipe *upipe)
     return urefcount_single(upipe->refcount);
 }
 
-/** @This checks if the pipe has no more references.
- *
- * @param upipe pointer to upipe
- * @return true if there is no reference to the pipe
- */
-static inline bool upipe_dead(struct upipe *upipe)
-{
-    assert(upipe != NULL);
-    return urefcount_dead(upipe->refcount);
-}
-
 /** @This gets the opaque member of a pipe.
  *
  * @param upipe pointer to upipe

--- a/include/upipe/uprobe.h
+++ b/include/upipe/uprobe.h
@@ -195,17 +195,6 @@ static inline bool uprobe_single(struct uprobe *uprobe)
     return urefcount_single(uprobe->refcount);
 }
 
-/** @This checks if the probe has no more references.
- *
- * @param uprobe pointer to uprobe
- * @return true if there is no reference to the probe
- */
-static inline bool uprobe_dead(struct uprobe *uprobe)
-{
-    assert(uprobe != NULL);
-    return urefcount_dead(uprobe->refcount);
-}
-
 /** @This initializes a uprobe structure. It is typically called by the
  * application or a pipe creating inner pipes (on a structure already
  * allocated by the master object).

--- a/include/upipe/urefcount.h
+++ b/include/upipe/urefcount.h
@@ -80,13 +80,13 @@ static inline void urefcount_reset(struct urefcount *refcount)
 /** @This increments a reference counter.
  *
  * @param refcount pointer to a urefcount structure
- * @return same pointer to a urefcount structure
+ * @return previous refcount value
  */
-static inline struct urefcount *urefcount_use(struct urefcount *refcount)
+static inline uint32_t urefcount_use(struct urefcount *refcount)
 {
     if (refcount != NULL && refcount->cb != NULL)
-        uatomic_fetch_add(&refcount->refcount, 1);
-    return refcount;
+        return uatomic_fetch_add(&refcount->refcount, 1);
+    return 0;
 }
 
 /** @This decrements a reference counter, and possibly frees the object if

--- a/lib/upipe-ts/upipe_ts_demux.c
+++ b/lib/upipe-ts/upipe_ts_demux.c
@@ -1504,7 +1504,7 @@ static void upipe_ts_demux_program_handle_pcr(struct upipe *upipe,
  */
 static void upipe_ts_demux_program_check_pcr(struct upipe *upipe)
 {
-    if (upipe_dead(upipe))
+    if (urefcount_dead(upipe->refcount))
         return;
 
     struct upipe_ts_demux_program *upipe_ts_demux_program =

--- a/lib/upipe/upump_common.c
+++ b/lib/upipe/upump_common.c
@@ -139,10 +139,9 @@ void upump_common_init(struct upump *upump)
  */
 void upump_common_dispatch(struct upump *upump)
 {
-    struct urefcount *refcount =
-        upump->refcount != NULL && !urefcount_dead(upump->refcount) ?
-        upump->refcount : NULL;
-    urefcount_use(refcount);
+    struct urefcount *refcount = upump->refcount;
+    if (urefcount_use(refcount) == 0)
+        refcount = NULL;
     upump->cb(upump);
     urefcount_release(refcount);
 }
@@ -190,10 +189,9 @@ void upump_common_clean(struct upump *upump)
             upump_blocker_common_from_uchain(uchain);
         struct upump_blocker *blocker =
             upump_blocker_common_to_upump_blocker(blocker_common);
-        struct urefcount *refcount =
-            upump->refcount != NULL && !urefcount_dead(upump->refcount) ?
-            upump->refcount : NULL;
-        urefcount_use(refcount);
+        struct urefcount *refcount = upump->refcount;
+        if (urefcount_use(refcount) == 0)
+            refcount = NULL;
         blocker->cb(blocker);
         urefcount_release(refcount);
     }


### PR DESCRIPTION
Note: I am not 100% sure about the last patch.

If we can crash on urefcount_release() if the refcount was already 0, couldn't we also crash on the upump callback?