### PR TITLE
upipe-pthread: depends on -lpthread

### DIFF
--- a/lib/upipe-pthread/libupipe_pthread.pc.in
+++ b/lib/upipe-pthread/libupipe_pthread.pc.in
@@ -7,4 +7,5 @@ Description: Upipe multimedia framework, pthread modules
 Version: @VERSION@
 Requires: libupipe
 Libs: -L${libdir} -lupipe_pthread
+Libs.private: -lpthread
 Cflags: -I${includedir}


### PR DESCRIPTION
We need to know this when using a static upipe build, else we get:
libupipe_pthread.a(libupipe_pthread_la-uprobe_pthread_upump_mgr.o): undefined reference to symbol 'pthread_key_delete@@GLIBC_2.2.5'

We don't use autoconf's PTHREAD_LIBS because it hides -lpthread behind -pthread