### PR TITLE
always initialize upipe_mgr to 0

### DIFF
--- a/lib/upipe-amt/upipe_amt_source.c
+++ b/lib/upipe-amt/upipe_amt_source.c
@@ -559,6 +559,7 @@ struct upipe_mgr *upipe_amtsrc_mgr_alloc(const char *amt_relay)
     if (unlikely(amtsrc_mgr == NULL))
         return NULL;
 
+    memset(amtsrc_mgr, 0, sizeof(*amtsrc_mgr));
     if (!inet_aton(amt_relay, &amtsrc_mgr->amt_addr) ||
         amt_init(htonl(amtsrc_mgr->amt_addr.s_addr))) {
         free(amtsrc_mgr);

--- a/lib/upipe-filters/upipe_filter_decode.c
+++ b/lib/upipe-filters/upipe_filter_decode.c
@@ -388,6 +388,7 @@ struct upipe_mgr *upipe_fdec_mgr_alloc(void)
     if (unlikely(fdec_mgr == NULL))
         return NULL;
 
+    memset(fdec_mgr, 0, sizeof(*fdec_mgr));
     fdec_mgr->avcdec_mgr = NULL;
 
     urefcount_init(upipe_fdec_mgr_to_urefcount(fdec_mgr),

--- a/lib/upipe-filters/upipe_filter_encode.c
+++ b/lib/upipe-filters/upipe_filter_encode.c
@@ -599,6 +599,7 @@ struct upipe_mgr *upipe_fenc_mgr_alloc(void)
     if (unlikely(fenc_mgr == NULL))
         return NULL;
 
+    memset(fenc_mgr, 0, sizeof(*fenc_mgr));
     fenc_mgr->avcenc_mgr = NULL;
     fenc_mgr->x264_mgr = NULL;
 

--- a/lib/upipe-filters/upipe_filter_format.c
+++ b/lib/upipe-filters/upipe_filter_format.c
@@ -595,6 +595,7 @@ struct upipe_mgr *upipe_ffmt_mgr_alloc(void)
     if (unlikely(ffmt_mgr == NULL))
         return NULL;
 
+    memset(ffmt_mgr, 0, sizeof(*ffmt_mgr));
     ffmt_mgr->sws_mgr = NULL;
     ffmt_mgr->swr_mgr = NULL;
     ffmt_mgr->deint_mgr = upipe_filter_blend_mgr_alloc();

--- a/lib/upipe-modules/upipe_auto_source.c
+++ b/lib/upipe-modules/upipe_auto_source.c
@@ -227,6 +227,7 @@ struct upipe_mgr *upipe_auto_src_mgr_alloc(void)
     if (unlikely(upipe_auto_src_mgr == NULL))
         return NULL;
 
+    memset(upipe_auto_src_mgr, 0, sizeof (*upipe_auto_src_mgr));
     urefcount_init(upipe_auto_src_mgr_to_urefcount(upipe_auto_src_mgr),
                    upipe_auto_src_mgr_free);
     ulist_init(&upipe_auto_src_mgr->mgrs);

--- a/lib/upipe-modules/upipe_rtp_source.c
+++ b/lib/upipe-modules/upipe_rtp_source.c
@@ -294,6 +294,7 @@ struct upipe_mgr *upipe_rtpsrc_mgr_alloc(void)
     if (unlikely(rtpsrc_mgr == NULL))
         return NULL;
 
+    memset(rtpsrc_mgr, 0, sizeof(*rtpsrc_mgr));
     rtpsrc_mgr->udpsrc_mgr = upipe_udpsrc_mgr_alloc();
     rtpsrc_mgr->rtpd_mgr = upipe_rtpd_mgr_alloc();
 

--- a/lib/upipe-modules/upipe_sequential_source.c
+++ b/lib/upipe-modules/upipe_sequential_source.c
@@ -262,6 +262,7 @@ struct upipe_mgr *upipe_seq_src_mgr_alloc(void)
     if (unlikely(upipe_seq_src_mgr == NULL))
         return NULL;
 
+    memset(upipe_seq_src_mgr, 0, sizeof(*upipe_seq_src_mgr));
     urefcount_init(&upipe_seq_src_mgr->urefcount, upipe_seq_src_mgr_free);
     upipe_seq_src_mgr->mgr.refcount = &upipe_seq_src_mgr->urefcount;
     upipe_seq_src_mgr->mgr.signature = UPIPE_SEQ_SRC_SIGNATURE;

--- a/lib/upipe-modules/upipe_transfer.c
+++ b/lib/upipe-modules/upipe_transfer.c
@@ -681,6 +681,7 @@ struct upipe_mgr *upipe_xfer_mgr_alloc(uint8_t queue_length,
     if (unlikely(xfer_mgr == NULL))
         return NULL;
 
+    memset(xfer_mgr, 0, sizeof(*xfer_mgr));
     if (unlikely(!uqueue_init(&xfer_mgr->uqueue, queue_length,
                               xfer_mgr->extra))) {
         free(xfer_mgr);

--- a/lib/upipe-modules/upipe_worker_linear.c
+++ b/lib/upipe-modules/upipe_worker_linear.c
@@ -460,6 +460,7 @@ struct upipe_mgr *upipe_wlin_mgr_alloc(struct upipe_mgr *xfer_mgr)
     if (unlikely(wlin_mgr == NULL))
         return NULL;
 
+    memset(wlin_mgr, 0, sizeof(*wlin_mgr));
     wlin_mgr->qsrc_mgr = upipe_qsrc_mgr_alloc();
     wlin_mgr->qsink_mgr = upipe_qsink_mgr_alloc();
     wlin_mgr->xfer_mgr = upipe_mgr_use(xfer_mgr);

--- a/lib/upipe-modules/upipe_worker_sink.c
+++ b/lib/upipe-modules/upipe_worker_sink.c
@@ -362,6 +362,7 @@ struct upipe_mgr *upipe_wsink_mgr_alloc(struct upipe_mgr *xfer_mgr)
     if (unlikely(wsink_mgr == NULL))
         return NULL;
 
+    memset(wsink_mgr, 0, sizeof(*wsink_mgr));
     wsink_mgr->qsrc_mgr = upipe_qsrc_mgr_alloc();
     wsink_mgr->qsink_mgr = upipe_qsink_mgr_alloc();
     wsink_mgr->xfer_mgr = upipe_mgr_use(xfer_mgr);

--- a/lib/upipe-modules/upipe_worker_source.c
+++ b/lib/upipe-modules/upipe_worker_source.c
@@ -385,6 +385,7 @@ struct upipe_mgr *upipe_wsrc_mgr_alloc(struct upipe_mgr *xfer_mgr)
     if (unlikely(wsrc_mgr == NULL))
         return NULL;
 
+    memset(wsrc_mgr, 0, sizeof(*wsrc_mgr));
     wsrc_mgr->qsrc_mgr = upipe_qsrc_mgr_alloc();
     wsrc_mgr->qsink_mgr = upipe_qsink_mgr_alloc();
     wsrc_mgr->xfer_mgr = upipe_mgr_use(xfer_mgr);

--- a/lib/upipe-ts/upipe_ts_demux.c
+++ b/lib/upipe-ts/upipe_ts_demux.c
@@ -3115,6 +3115,7 @@ struct upipe_mgr *upipe_ts_demux_mgr_alloc(void)
     if (unlikely(ts_demux_mgr == NULL))
         return NULL;
 
+    memset(ts_demux_mgr, 0, sizeof(*ts_demux_mgr));
     ts_demux_mgr->null_mgr = upipe_null_mgr_alloc();
     ts_demux_mgr->setrap_mgr = upipe_setrap_mgr_alloc();
     ts_demux_mgr->idem_mgr = upipe_idem_mgr_alloc();

--- a/lib/upipe-ts/upipe_ts_mux.c
+++ b/lib/upipe-ts/upipe_ts_mux.c
@@ -4411,6 +4411,7 @@ struct upipe_mgr *upipe_ts_mux_mgr_alloc(void)
     if (unlikely(ts_mux_mgr == NULL))
         return NULL;
 
+    memset(ts_mux_mgr, 0, sizeof(*ts_mux_mgr));
     ts_mux_mgr->ts_encaps_mgr = upipe_ts_encaps_mgr_alloc();
     ts_mux_mgr->ts_tstd_mgr = upipe_ts_tstd_mgr_alloc();
     ts_mux_mgr->ts_psi_join_mgr = upipe_ts_psi_join_mgr_alloc();


### PR DESCRIPTION
This ensures that upipe_{err,command,event}_str are initialized properly