### PR TITLE
Bmd mirror

### DIFF
--- a/lib/upipe-blackmagic/include/DeckLinkAPI.h
+++ b/lib/upipe-blackmagic/include/DeckLinkAPI.h
@@ -150,6 +150,7 @@ enum _BMDDetectedVideoInputFormatFlags {
 
 typedef uint32_t BMDDeckLinkCapturePassthroughMode;
 enum _BMDDeckLinkCapturePassthroughMode {
+    bmdDeckLinkCapturePassthroughModeDisabled                    = /* 'pdis' */ 0x70646973,
     bmdDeckLinkCapturePassthroughModeDirect                      = /* 'pdir' */ 0x70646972,
     bmdDeckLinkCapturePassthroughModeCleanSwitch                 = /* 'pcln' */ 0x70636C6E
 };

--- a/lib/upipe-blackmagic/include/DeckLinkAPIVersion.h
+++ b/lib/upipe-blackmagic/include/DeckLinkAPIVersion.h
@@ -30,8 +30,8 @@
 #ifndef __DeckLink_API_Version_h__
 #define __DeckLink_API_Version_h__
 
-#define BLACKMAGIC_DECKLINK_API_VERSION					0x0a070000
-#define BLACKMAGIC_DECKLINK_API_VERSION_STRING			"10.7"
+#define BLACKMAGIC_DECKLINK_API_VERSION					0x0a080000
+#define BLACKMAGIC_DECKLINK_API_VERSION_STRING			"10.8"
 
 #endif	// __DeckLink_API_Version_h__
 

--- a/lib/upipe-blackmagic/upipe_blackmagic_source.cpp
+++ b/lib/upipe-blackmagic/upipe_blackmagic_source.cpp
@@ -1000,6 +1000,7 @@ static int upipe_bmd_src_set_uri(struct upipe *upipe, const char *uri)
     char *audio = NULL;
     char *video_bits = NULL;
     char *audio_bits = NULL;
+    bool mirror = true;
     const char *params = strchr(idx, '/');
     if (params) {
         char *paramsdup = strdup(params);
@@ -1020,6 +1021,8 @@ static int upipe_bmd_src_set_uri(struct upipe *upipe, const char *uri)
             } else if (IS_OPTION("video_bits=")) {
                 free(video_bits);
                 video_bits = config_stropt(ARG_OPTION("video_bits="));
+            } else if (IS_OPTION("nomirror")) {
+                mirror = false;
             }
 #undef IS_OPTION
 #undef ARG_OPTION
@@ -1027,6 +1030,11 @@ static int upipe_bmd_src_set_uri(struct upipe *upipe, const char *uri)
 
         free(paramsdup);
     }
+
+    deckLinkConfiguration->SetInt(bmdDeckLinkConfigCapturePassThroughMode,
+            mirror ? bmdDeckLinkCapturePassthroughModeDirect :
+            bmdDeckLinkCapturePassthroughModeDisabled);
+
 
     if (audio != NULL) {
         int i = 0;


### PR DESCRIPTION
Add an option to disable decklink mirroring, that is electrical wiring of the input to the output.

This helps when you're receiving and sending the same stream on the same card, else you are
not sure if your middle man is running properly.