### PR TITLE
upipe_m3u_reader: allow whitespace in attribute list

### DIFF
--- a/lib/upipe-modules/upipe_m3u_reader.c
+++ b/lib/upipe-modules/upipe_m3u_reader.c
@@ -480,9 +480,20 @@ static int upipe_m3u_reader_ext_x_stream_inf(struct upipe *upipe,
     UBASE_RETURN(upipe_m3u_reader_get_item(upipe, flow_def, &item));
 
     const char *iterator = line;
-    struct ustring name, value;
-    while (ubase_check(attribute_iterate(&iterator, &name, &value)) &&
-           iterator != NULL) {
+    while (true) {
+        struct ustring name, value;
+        int ret;
+
+        ret = attribute_iterate(&iterator, &name, &value);
+        if (!ubase_check(ret)) {
+            upipe_err_va(upipe, "fail to parse attribute list at %s",
+                         iterator);
+            return ret;
+        }
+
+        if (iterator == NULL)
+            break;
+
         char value_str[value.len + 1];
         int err = ustring_cpy(value, value_str, sizeof (value_str));
         if (unlikely(!ubase_check(err))) {

--- a/lib/upipe-modules/upipe_m3u_reader.c
+++ b/lib/upipe-modules/upipe_m3u_reader.c
@@ -94,6 +94,8 @@ static int attribute_iterate(const char **item,
         return UBASE_ERR_NONE;
     }
 
+    /* remove whitespaces */
+    tmp = ustring_shift_while(tmp, " ");
     *name = ustring_split_while(&tmp, name_set);
     if (unlikely(!ustring_match_str(tmp, "=")))
         return UBASE_ERR_INVALID;
@@ -106,8 +108,10 @@ static int attribute_iterate(const char **item,
         tmp = ustring_shift(tmp, 1);
     }
     else {
-        *value = ustring_split_until(&tmp, ",");
+        *value = ustring_split_until(&tmp, " ,");
     }
+    /* remove whitespaces */
+    tmp = ustring_shift_while(tmp, " ");
     if (ustring_match_str(tmp, ","))
         tmp = ustring_shift(tmp, 1);
     else if (!ustring_is_empty(tmp))

--- a/lib/upipe-modules/upipe_m3u_reader.c
+++ b/lib/upipe-modules/upipe_m3u_reader.c
@@ -480,6 +480,7 @@ static int upipe_m3u_reader_ext_x_stream_inf(struct upipe *upipe,
     UBASE_RETURN(upipe_m3u_reader_get_item(upipe, flow_def, &item));
 
     const char *iterator = line;
+    bool bandwidth_present = false;
     while (true) {
         struct ustring name, value;
         int ret;
@@ -510,6 +511,8 @@ static int upipe_m3u_reader_ext_x_stream_inf(struct upipe *upipe,
             err = uref_m3u_master_set_bandwidth(item, bandwidth);
             if (unlikely(!ubase_check(err)))
                 upipe_err_va(upipe, "fail to set bandwidth to %s", value_str);
+            else
+                bandwidth_present = true;
         }
         else if (!ustring_cmp_str(name, "CODECS")) {
             err = uref_m3u_master_set_codecs(item, value_str);
@@ -532,6 +535,9 @@ static int upipe_m3u_reader_ext_x_stream_inf(struct upipe *upipe,
                           (int)value.len, value.at);
         }
     }
+
+    if (!bandwidth_present)
+        upipe_warn(upipe, "no bandwidth attribute found");
 
     return UBASE_ERR_NONE;
 }


### PR DESCRIPTION
Allow whitespace before and after comma in an attibute list.