### PR TITLE
fix pkg-config --static --libs libupipe

### DIFF
--- a/lib/upipe/libupipe.pc.in
+++ b/lib/upipe/libupipe.pc.in
@@ -6,5 +6,5 @@ Name: libupipe
 Description: upipe multimedia framework, core library
 Version: @VERSION@
 Libs: -L${libdir} -lupipe
-Libs.private: -lrt
+Libs.private: -lrt -lm
 Cflags: -I${includedir}


### PR DESCRIPTION
libupipe depends on libm, we need to know this if we link to a static libupipe