### PR TITLE
upipe_delay: supports negative delays

### DIFF
--- a/include/upipe-modules/upipe_delay.h
+++ b/include/upipe-modules/upipe_delay.h
@@ -43,9 +43,9 @@ extern "C" {
 enum upipe_delay_command {
     UPIPE_DELAY_SENTINEL = UPIPE_CONTROL_LOCAL,
 
-    /** returns the current delay being set into urefs (uint64_t **) */
+    /** returns the current delay being set into urefs (int64_t **) */
     UPIPE_DELAY_GET_DELAY,
-    /** sets the delay to set into urefs (uint64_t *) */
+    /** sets the delay to set into urefs (int64_t *) */
     UPIPE_DELAY_SET_DELAY
 };
 
@@ -61,7 +61,7 @@ struct upipe_mgr *upipe_delay_mgr_alloc(void);
  * @param delay_p filled with the current delay
  * @return an error code
  */
-static inline int upipe_delay_get_delay(struct upipe *upipe, uint64_t *delay_p)
+static inline int upipe_delay_get_delay(struct upipe *upipe, int64_t *delay_p)
 {
     return upipe_control(upipe, UPIPE_DELAY_GET_DELAY,
                          UPIPE_DELAY_SIGNATURE, delay_p);
@@ -73,7 +73,7 @@ static inline int upipe_delay_get_delay(struct upipe *upipe, uint64_t *delay_p)
  * @param delay delay to set
  * @return an error code
  */
-static inline int upipe_delay_set_delay(struct upipe *upipe, uint64_t delay)
+static inline int upipe_delay_set_delay(struct upipe *upipe, int64_t delay)
 {
     return upipe_control(upipe, UPIPE_DELAY_SET_DELAY,
                          UPIPE_DELAY_SIGNATURE, delay);

--- a/lib/upipe-modules/upipe_delay.c
+++ b/lib/upipe-modules/upipe_delay.c
@@ -60,7 +60,7 @@ struct upipe_delay {
     struct uchain request_list;
 
     /** delay to set */
-    uint64_t delay;
+    int64_t delay;
 
     /** public upipe structure */
     struct upipe upipe;
@@ -137,7 +137,7 @@ static int upipe_delay_set_flow_def(struct upipe *upipe, struct uref *flow_def)
  * @param delay_p filled with the current delay
  * @return an error code
  */
-static int _upipe_delay_get_delay(struct upipe *upipe, uint64_t *delay_p)
+static int _upipe_delay_get_delay(struct upipe *upipe, int64_t *delay_p)
 {
     struct upipe_delay *upipe_delay = upipe_delay_from_upipe(upipe);
     *delay_p = upipe_delay->delay;
@@ -150,7 +150,7 @@ static int _upipe_delay_get_delay(struct upipe *upipe, uint64_t *delay_p)
  * @param delay delay to set
  * @return an error code
  */
-static int _upipe_delay_set_delay(struct upipe *upipe, uint64_t delay)
+static int _upipe_delay_set_delay(struct upipe *upipe, int64_t delay)
 {
     struct upipe_delay *upipe_delay = upipe_delay_from_upipe(upipe);
     upipe_delay->delay = delay;
@@ -194,12 +194,12 @@ static int upipe_delay_control(struct upipe *upipe, int command, va_list args)
 
         case UPIPE_DELAY_GET_DELAY: {
             UBASE_SIGNATURE_CHECK(args, UPIPE_DELAY_SIGNATURE)
-            uint64_t *delay_p = va_arg(args, uint64_t *);
+            int64_t *delay_p = va_arg(args, int64_t *);
             return _upipe_delay_get_delay(upipe, delay_p);
         }
         case UPIPE_DELAY_SET_DELAY: {
             UBASE_SIGNATURE_CHECK(args, UPIPE_DELAY_SIGNATURE)
-            uint64_t delay = va_arg(args, uint64_t);
+            int64_t delay = va_arg(args, int64_t);
             return _upipe_delay_set_delay(upipe, delay);
         }
         default:

--- a/tests/upipe_delay_test.c
+++ b/tests/upipe_delay_test.c
@@ -54,7 +54,7 @@
 #define UBUF_POOL_DEPTH 0
 #define UPROBE_LOG_LEVEL UPROBE_LOG_DEBUG
 
-static uint64_t delay = 0;
+static int64_t delay = 0;
 static unsigned int nb_packets = 0;
 
 /** definition of our uprobe */

--- a/tests/upipe_file_test.c
+++ b/tests/upipe_file_test.c
@@ -96,7 +96,7 @@ static int catch(struct uprobe *uprobe, struct upipe *upipe,
 int main(int argc, char *argv[])
 {
     const char *src_file, *sink_file;
-    uint64_t delay = 0;
+    int64_t delay = 0;
     enum upipe_fsink_mode mode = UPIPE_FSINK_CREATE;
     int opt;
     while ((opt = getopt(argc, argv, "d:ao")) != -1) {

--- a/tests/upipe_seq_src_test.c
+++ b/tests/upipe_seq_src_test.c
@@ -91,7 +91,7 @@ unsigned source_nb = SOURCE_MAX + 1;
 
 int main(int argc, char *argv[])
 {
-    uint64_t delay = 0;
+    int64_t delay = 0;
     int opt;
     while ((opt = getopt(argc, argv, "d:ao")) != -1) {
         switch (opt) {


### PR DESCRIPTION
uref_clock_date_add already handles int64_t