### PR TITLE
upipe-av: include raw bits per sample in audio flow if known

### DIFF
--- a/include/upipe/uref_sound_flow.h
+++ b/include/upipe/uref_sound_flow.h
@@ -50,6 +50,8 @@ UREF_ATTR_STRING_VA(sound_flow, channel, "s.channel[%" PRIu8"]",
 UREF_ATTR_SMALL_UNSIGNED(sound_flow, channels, "s.channels", number of channels)
 UREF_ATTR_SMALL_UNSIGNED(sound_flow, sample_size, "s.sample_size",
         size in octets of a sample of an audio plane)
+UREF_ATTR_SMALL_UNSIGNED(sound_flow, raw_sample_size, "s.sample_bits",
+        size in bits of an audio sample)
 UREF_ATTR_UNSIGNED(sound_flow, rate, "s.rate", samples per second)
 UREF_ATTR_UNSIGNED(sound_flow, samples, "s.samples", number of samples)
 UREF_ATTR_UNSIGNED(sound_flow, align, "s.align", alignment in octets)

--- a/lib/upipe-av/upipe_avcodec_decode.c
+++ b/lib/upipe-av/upipe_avcodec_decode.c
@@ -487,6 +487,11 @@ static int upipe_avcdec_get_buffer_sound(struct AVCodecContext *context,
     if (context->sample_rate)
         UBASE_FATAL(upipe, uref_sound_flow_set_rate(flow_def_attr,
                                               context->sample_rate))
+
+    if (context->bits_per_raw_sample)
+        UBASE_FATAL(upipe, uref_sound_flow_set_raw_sample_size(flow_def_attr,
+                                              context->bits_per_raw_sample))
+
     if (context->frame_size)
         UBASE_FATAL(upipe, uref_sound_flow_set_samples(flow_def_attr,
                                                  context->frame_size))


### PR DESCRIPTION
This is set for example by the libavcodec s302m decoder