### PR TITLE
s337 framer: 20/24 bits support

### DIFF
--- a/lib/upipe-framers/upipe_s337_framer.c
+++ b/lib/upipe-framers/upipe_s337_framer.c
@@ -1,26 +1,30 @@
 /*
- * Copyright (C) 2016 OpenHeadend S.A.R.L.
+ * Copyright (C) 2016-2017 Open Broadcast Systems Ltd
  *
- * Authors: Christophe Massiot
+ * Authors: Rafaël Carré
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as published by
- * the Free Software Foundation; either version 2.1 of the License, or
- * (at your option) any later version.
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Lesser General Public License for more details.
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
  *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
 /** @file
  * @short Upipe module building frames from chunks of a SMPTE 337 stream
- * This pipe only supports the 16-bit mode.
  *
  * Normative references:
  *  - SMPTE 337-2008 (non-PCM in AES3)
@@ -29,42 +33,26 @@
  */
 
 #include <upipe/ubase.h>
-#include <upipe/ulist.h>
 #include <upipe/uprobe.h>
 #include <upipe/uref.h>
-#include <upipe/uref_flow.h>
-#include <upipe/uref_block.h>
-#include <upipe/uref_block_flow.h>
 #include <upipe/uref_sound_flow.h>
-#include <upipe/uref_clock.h>
-#include <upipe/uclock.h>
-#include <upipe/ubuf.h>
+#include <upipe/uref_sound.h>
 #include <upipe/upipe.h>
+#include <upipe/udict.h>
 #include <upipe/upipe_helper_upipe.h>
 #include <upipe/upipe_helper_urefcount.h>
 #include <upipe/upipe_helper_void.h>
-#include <upipe/upipe_helper_sync.h>
-#include <upipe/upipe_helper_uref_stream.h>
 #include <upipe/upipe_helper_output.h>
-#include <upipe/upipe_helper_input.h>
 #include <upipe/upipe_helper_flow_def.h>
 #include <upipe-framers/upipe_s337_framer.h>
 
-#include <stdlib.h>
-#include <stdbool.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <assert.h>
-
 #include <bitstream/smpte/337.h>
 
-/** @internal @This is the private context of an s337f pipe. */
+/** upipe_s337f structure */
 struct upipe_s337f {
     /** refcount management structure */
     struct urefcount urefcount;
 
-    /* output stuff */
     /** pipe acting as output */
     struct upipe *output;
     /** output flow definition packet */
@@ -73,275 +61,266 @@ struct upipe_s337f {
     enum upipe_helper_output_state output_state;
     /** list of output requests */
     struct uchain request_list;
+
+    /** buffered uref */
+    struct uref *uref;
+
+    /** size in samples of buffered uref */
+    ssize_t samples;
+
+    /** bits per raw sample */
+    uint8_t bits;
+
     /** input flow definition packet */
     struct uref *flow_def_input;
-    /** attributes in the sequence header */
+    /** frame definition packet */
     struct uref *flow_def_attr;
-
-    /* sync parsing stuff */
-    /** sample rate */
-    uint64_t sample_rate;
-    /** data type of the last non-discarded frame */
-    uint8_t data_type;
-    /** data stream of the last non-discarded frame */
-    uint8_t data_stream;
-
-    /* octet stream stuff */
-    /** next uref to be processed */
-    struct uref *next_uref;
-    /** original size of the next uref */
-    size_t next_uref_size;
-    /** urefs received after next uref */
-    struct uchain urefs;
-
-    /* octet stream parser stuff */
-    /** current size of next frame (in next_uref) */
-    ssize_t next_frame_size;
-    /** true if next frame payload should be discarded */
-    bool next_frame_discard;
-    /** true if we have thrown the sync_acquired event (that means we found a
-     * header) */
-    bool acquired;
 
     /** public upipe structure */
     struct upipe upipe;
 };
 
-UPIPE_HELPER_UPIPE(upipe_s337f, upipe, UPIPE_S337F_SIGNATURE)
+UPIPE_HELPER_UPIPE(upipe_s337f, upipe, UPIPE_S337F_SIGNATURE);
 UPIPE_HELPER_UREFCOUNT(upipe_s337f, urefcount, upipe_s337f_free)
-UPIPE_HELPER_VOID(upipe_s337f)
-UPIPE_HELPER_SYNC(upipe_s337f, acquired)
-UPIPE_HELPER_UREF_STREAM(upipe_s337f, next_uref, next_uref_size, urefs, NULL)
-
+UPIPE_HELPER_VOID(upipe_s337f);
 UPIPE_HELPER_OUTPUT(upipe_s337f, output, flow_def, output_state, request_list)
 UPIPE_HELPER_FLOW_DEF(upipe_s337f, flow_def_input, flow_def_attr)
 
-/** @internal @This allocates an s337f pipe.
+/** @internal @This allocates a s337f pipe.
  *
  * @param mgr common management structure
  * @param uprobe structure used to raise events
  * @param signature signature of the pipe allocator
  * @param args optional arguments
- * @return pointer to upipe or NULL in case of allocation error
+ * @return pointer to upipe or S337F in case of allocation error
  */
 static struct upipe *upipe_s337f_alloc(struct upipe_mgr *mgr,
-                                       struct uprobe *uprobe,
-                                       uint32_t signature, va_list args)
+                                      struct uprobe *uprobe,
+                                      uint32_t signature, va_list args)
 {
     struct upipe *upipe = upipe_s337f_alloc_void(mgr, uprobe, signature, args);
     if (unlikely(upipe == NULL))
         return NULL;
 
     struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
+
     upipe_s337f_init_urefcount(upipe);
-    upipe_s337f_init_sync(upipe);
-    upipe_s337f_init_uref_stream(upipe);
     upipe_s337f_init_output(upipe);
     upipe_s337f_init_flow_def(upipe);
-    upipe_s337f->data_type = UINT8_MAX;
-    upipe_s337f->data_stream = UINT8_MAX;
-    upipe_s337f->next_frame_size = -1;
-    upipe_s337f->next_frame_discard = true;
-    upipe_throw_ready(upipe);
-    return upipe;
+    upipe_s337f->uref = NULL;
+
+    upipe_throw_ready(&upipe_s337f->upipe);
+    return &upipe_s337f->upipe;
 }
 
-/** @internal @This scans for a sync word.
- *
- * @param upipe description structure of the pipe
- * @param dropped_p filled with the number of octets to drop before the sync
- * @return true if a sync word was found
+/** @internal @This finds the position of the s337m sync word in the frame
  */
-static bool upipe_s337f_scan(struct upipe *upipe, size_t *dropped_p)
+static ssize_t upipe_s337f_sync(struct upipe *upipe, struct uref *uref)
 {
     struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
-    while (ubase_check(uref_block_scan(upipe_s337f->next_uref, dropped_p,
-                                       S337_PREAMBLE_A1))) {
-        uint8_t preamble[3];
-        if (!ubase_check(uref_block_extract(upipe_s337f->next_uref,
-                        *dropped_p + 1, 3, preamble)))
-            return false;
 
-        if (preamble[0] == S337_PREAMBLE_A2 &&
-            preamble[1] == S337_PREAMBLE_B1 &&
-            preamble[2] == S337_PREAMBLE_B2)
-            return true;
-        (*dropped_p)++;
+    size_t size = 0;
+    uref_sound_size(uref, &size, NULL);
+
+    if (upipe_s337f->bits == 16) {
+        // TODO
+        const int16_t *in;
+        uref_sound_read_int16_t(uref, 0, -1, &in, 1);
+
+        for (size_t i = 0; i < size; i++) // TODO: find sample
+            if ((in[2*i+0] == (int16_t)0xf872 && in[2*i+1] == 0x4e1f)) {
+                uref_sound_unmap(uref, 0, -1, 1);
+                return i;
+            }
+
+        uref_sound_unmap(uref, 0, -1, 1);
+    } else {
+        const int32_t *in;
+        uref_sound_read_int32_t(uref, 0, -1, &in, 1);
+
+        for (size_t i = 0; i < size; i++)
+            if ((in[2*i+0] == (0x6f872 << 12) && in[2*i+1] == (0x54e1f << 12)) ||
+                    ((in[2*i+0] == (0x96f872 << 8) && in[2*i+1] == (0xa54e1f << 8)))) {
+                uref_sound_unmap(uref, 0, -1, 1);
+                return i;
+            }
+
+        uref_sound_unmap(uref, 0, -1, 1);
     }
-    return false;
+
+    return -1;
 }
 
-/** @internal @This checks if a burst is complete.
- *
- * @param upipe description structure of the pipe
- * @param true if the burst is complete
- */
-static bool upipe_s337f_check_frame(struct upipe *upipe)
-{
-    struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
-    size_t size;
-    if (!ubase_check(uref_block_size(upipe_s337f->next_uref, &size))) {
-        upipe_s337f->next_frame_discard = true;
-        return true;
-    }
-    return size >= upipe_s337f->next_frame_size + S337_PREAMBLE_SIZE;
-}
-
-/** @internal @This parses a new s337 header.
- *
- * @param upipe description structure of the pipe
- */
-static void upipe_s337f_parse_preamble(struct upipe *upipe)
-{
-    struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
-    uint8_t preamble[S337_PREAMBLE_SIZE];
-    if (!ubase_check(uref_block_extract(upipe_s337f->next_uref, 0,
-                    S337_PREAMBLE_SIZE, preamble)))
-        return; /* not enough data */
-
-    uint8_t data_type = s337_get_data_type(preamble);
-    uint8_t data_mode = s337_get_data_mode(preamble);
-    bool error = s337_get_error(preamble);
-    uint8_t data_stream = s337_get_data_stream(preamble);
-    uint8_t data_type_dep = s337_get_data_type_dep(preamble);
-    upipe_s337f->next_frame_size = s337_get_length(preamble) + 7;
-    upipe_s337f->next_frame_size /= 8;
-
-    if (data_type != S337_TYPE_A52 && data_type != S337_TYPE_A52E) {
-        upipe_s337f->next_frame_discard = true;
-        return;
-    }
-
-    if (data_mode != S337_MODE_16) {
-        upipe_err_va(upipe, "unsupported data mode (%"PRIu8")", data_mode);
-        upipe_s337f->next_frame_discard = true;
-        return;
-    }
-
-    upipe_s337f->next_frame_discard = false;
-    if (error)
-        upipe_warn(upipe, "error flag set");
-
-    if (upipe_s337f->data_stream != data_stream) {
-        upipe_dbg_va(upipe, "now following stream %"PRIu8, data_stream);
-        upipe_s337f->data_stream = data_stream;
-    }
-
-    if (upipe_s337f->data_type == data_type)
-        return;
-    upipe_s337f->data_type = data_type;
-
-    if (data_type_dep & S337_TYPE_A52_REP_RATE_FLAG)
-        upipe_warn(upipe, "repetition rate flag set");
-    if (data_type_dep & S337_TYPE_A52_NOT_FULL_SVC)
-        upipe_warn(upipe, "not full service flag set");
-
-    struct uref *flow_def = upipe_s337f_alloc_flow_def_attr(upipe);
-    if (unlikely(flow_def == NULL)) {
-        upipe_throw_fatal(upipe, UBASE_ERR_ALLOC);
-        return;
-    }
-
-    if (data_type == S337_TYPE_A52)
-        UBASE_FATAL(upipe, uref_flow_set_def(flow_def, "block.ac3.sound."))
-    else
-        UBASE_FATAL(upipe, uref_flow_set_def(flow_def, "block.eac3.sound."))
-
-    flow_def = upipe_s337f_store_flow_def_attr(upipe, flow_def);
-    if (unlikely(!flow_def)) {
-        upipe_throw_fatal(upipe, UBASE_ERR_ALLOC);
-        return;
-    }
-    upipe_s337f_store_flow_def(upipe, flow_def);
-}
-
-/** @internal @This handles and outputs a frame.
- *
- * @param upipe description structure of the pipe
- * @param upump_p reference to pump that generated the buffer
- */
-static void upipe_s337f_output_frame(struct upipe *upipe,
-                                     struct upump **upump_p)
-{
-    struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
-    /* assume repetition rate and shift dts backwards */
-    size_t samples = upipe_s337f->next_uref_size / 4;
-    uint64_t dts_shift = (uint64_t)samples * UCLOCK_FREQ /
-                         upipe_s337f->sample_rate;
-    struct uref au_uref_s = *upipe_s337f->next_uref;
-
-    /* consume burst preamble */
-    upipe_s337f_consume_uref_stream(upipe, S337_PREAMBLE_SIZE);
-
-    /* extract burst payload */
-    struct uref *uref = upipe_s337f_extract_uref_stream(upipe,
-            upipe_s337f->next_frame_size);
-    if (unlikely(uref == NULL)) {
-        upipe_throw_fatal(upipe, UBASE_ERR_ALLOC);
-        return;
-    }
-
-    uint64_t date;
-#define SET_DATE(dv)                                                        \
-    if (ubase_check(uref_clock_get_dts_##dv(&au_uref_s, &date)))            \
-        uref_clock_set_dts_##dv(uref, date - dts_shift);
-    SET_DATE(sys)
-    SET_DATE(prog)
-    SET_DATE(orig)
-#undef SET_DATE
-
-    upipe_s337f_output(upipe, uref, upump_p);
-}
-
-/** @internal @This tries to output frames from the queue of input buffers.
- *
- * @param upipe description structure of the pipe
- * @param upump_p reference to pump that generated the buffer
- */
-static void upipe_s337f_work(struct upipe *upipe, struct upump **upump_p)
-{
-    struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
-    while (upipe_s337f->next_uref != NULL) {
-        if (upipe_s337f->next_frame_size == -1) {
-            size_t dropped = 0;
-            bool ret = upipe_s337f_scan(upipe, &dropped);
-            upipe_s337f_consume_uref_stream(upipe, dropped);
-            if (!ret)
-                return;
-        }
-
-        if (upipe_s337f->next_frame_size == -1) {
-            upipe_s337f_parse_preamble(upipe);
-            if (upipe_s337f->next_frame_size == -1)
-                return; /* not enough data */
-        }
-
-        if (!upipe_s337f_check_frame(upipe))
-            return;
-
-        if (upipe_s337f->next_frame_discard) {
-            upipe_s337f_consume_uref_stream(upipe,
-                                            upipe_s337f->next_frame_size);
-        } else {
-            upipe_s337f_sync_acquired(upipe);
-            upipe_s337f_output_frame(upipe, upump_p);
-        }
-        upipe_s337f->next_frame_size = -1;
-        upipe_s337f->next_frame_discard = true;
-    }
-}
-
-/** @internal @This receives data.
+/** @internal
  *
  * @param upipe description structure of the pipe
  * @param uref uref structure
  * @param upump_p reference to pump that generated the buffer
  */
-static void upipe_s337f_input(struct upipe *upipe, struct uref *uref,
-                              struct upump **upump_p)
+static void upipe_s337f_input(struct upipe *upipe, struct uref *uref, struct upump **upump_p)
 {
-    upipe_s337f_append_uref_stream(upipe, uref);
-    upipe_s337f_work(upipe, upump_p);
+    struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
+    struct uref *output = upipe_s337f->uref;
+
+    ssize_t sync = upipe_s337f_sync(upipe, uref);
+
+    if (sync == -1) {
+        if (output) {
+            upipe_err(upipe, "Sync lost");
+            uref_free(output);
+            upipe_s337f->uref = NULL;
+        }
+        upipe_err(upipe, "No sync");
+        uref_free(uref);
+        return;
+    } else if (!output) {
+        upipe_notice(upipe, "Found synchro");
+    }
+
+    if (output) {
+        size_t size[2];
+        uref_sound_size(uref, &size[0], NULL);
+        uref_sound_size(output, &size[1], NULL);
+
+        const int32_t *in32;
+        int32_t *out32;
+        const int16_t *in16;
+        int16_t *out16;
+
+        if (upipe_s337f->bits == 16) {
+            if (!ubase_check(uref_sound_read_int16_t(uref, 0, sync, &in16, 1))) {
+                upipe_err(upipe, "Could not map audio uref for reading");
+            }
+
+            if (!ubase_check(uref_sound_write_int16_t(output, 0, -1, &out16, 1))) {
+                upipe_err(upipe, "Could not map buffered audio uref for writing");
+            }
+        } else {
+            if (!ubase_check(uref_sound_read_int32_t(uref, 0, sync, &in32, 1))) {
+                upipe_err(upipe, "Could not map audio uref for reading");
+            }
+
+            if (!ubase_check(uref_sound_write_int32_t(output, 0, -1, &out32, 1))) {
+                upipe_err(upipe, "Could not map buffered audio uref for writing");
+            }
+        }
+
+        size_t out_size = size[0] - upipe_s337f->samples;
+        if (out_size < sync) {
+            upipe_warn(upipe, "Frame too small");
+        }
+
+        out_size *= 2; /* channels */
+
+        uint32_t hdr[2]; /* Pc + Pd */
+
+        if (upipe_s337f->bits == 16) {
+            out_size *= 2; /* s16 */
+            memcpy(&out16[2*upipe_s337f->samples], in16, out_size);
+
+            hdr[0] = out16[2];
+            hdr[1] = out16[3];
+        } else {
+            out_size *= 4; /* s32 */
+            memcpy(&out32[2*upipe_s337f->samples], in32, out_size);
+
+            int bits = (out32[0] == 0x6f872 << 12) ? 20 : 24;
+
+            hdr[0] = out32[2] >> 16;
+            hdr[1] = out32[3] >> (32 - bits);
+        }
+
+        unsigned data_stream_number =  hdr[0] >> 13;
+        unsigned data_type_dependent= (hdr[0] >>  8) & 0x1f;
+        unsigned error_flag         = (hdr[0] >>  7) & 0x1;
+        unsigned data_mode          = (hdr[0] >>  5) & 0x3;
+        unsigned data_type          = (hdr[0] >>  0) & 0x1f;
+
+        if (error_flag)
+            upipe_err(upipe, "error flag set");
+
+        struct uref *flow_def = upipe_s337f_alloc_flow_def_attr(upipe);
+        if (unlikely(flow_def == NULL)) {
+            upipe_throw_fatal(upipe, UBASE_ERR_ALLOC);
+        } else {
+            size_t frame_size = size[0];
+            if (frame_size == 1601 || frame_size == 1602) { /* NTSC */
+                uref_clock_set_latency(flow_def, UCLOCK_FREQ * 2 * 1001 / 30000);
+            } else
+                uref_clock_set_latency(flow_def, UCLOCK_FREQ * 2 * frame_size / 48000);
+
+            int bits = upipe_s337f->bits;
+            if (bits > 16)
+                bits = 32;
+
+            switch (data_type) {
+            case S337_TYPE_DOLBY_E:
+                UBASE_FATAL(upipe, uref_flow_set_def_va(flow_def, "sound.s%d.s337.dolbye.", bits))
+                break;
+            case S337_TYPE_A52:
+                UBASE_FATAL(upipe, uref_flow_set_def_va(flow_def, "sound.s%d.s337.a52.", bits))
+                break;
+            case S337_TYPE_A52E:
+                UBASE_FATAL(upipe, uref_flow_set_def_va(flow_def, "sound.s%d.s337.a52e.", bits))
+                break;
+            default:
+                upipe_warn_va(upipe, "Unhandled data type %u", data_type);
+            }
+
+            flow_def = upipe_s337f_store_flow_def_attr(upipe, flow_def);
+            if (flow_def)
+                upipe_s337f_store_flow_def(upipe, flow_def);
+        }
+
+        size_t samples = hdr[1] / upipe_s337f->bits / 2 /* channels */ + 2 /* header */;
+        if (samples > size[0]) {
+            upipe_err_va(upipe, "S337 frame truncated");
+        }
+
+        if (0) {
+            upipe_notice_va(upipe, "%d %d %d %d %d", data_stream_number,
+                    data_type_dependent, error_flag, data_mode, data_type);
+            upipe_notice_va(upipe, "%u bytes", hdr[1] / 8);
+        }
+
+        uref_sound_unmap(uref, 0, sync, 1);
+        uref_sound_unmap(output, 0, -1, 1);
+    }
+
+    /* discard leading samples up to sync word */
+    if (upipe_s337f->bits == 16) {
+        int16_t *samples;
+        if (ubase_check(uref_sound_write_int16_t(uref, 0, -1, &samples, 1))) {
+            size_t size;
+            uref_sound_size(uref, &size, NULL);
+            size_t s = 2 /* stereo */ * 2 /* s16 */ * (size - sync);
+            memmove(samples, &samples[2*sync], s); // discard up to sync word
+
+            uref_sound_unmap(uref, 0, -1, 1);
+            upipe_s337f->samples = size - sync;
+        } else {
+            upipe_err(upipe, "Could not map audio uref for writing");
+        }
+    } else {
+        int32_t *samples;
+        if (ubase_check(uref_sound_write_int32_t(uref, 0, -1, &samples, 1))) {
+            size_t size;
+            uref_sound_size(uref, &size, NULL);
+            size_t s = 2 /* stereo */ * 4 /* s32 */ * (size - sync);
+            memmove(samples, &samples[2*sync], s); // discard up to sync word
+
+            uref_sound_unmap(uref, 0, -1, 1);
+            upipe_s337f->samples = size - sync;
+        } else {
+            upipe_err(upipe, "Could not map audio uref for writing");
+        }
+    }
+
+    /* buffer next uref */
+    upipe_s337f->uref = uref;
+
+    if (output)
+        upipe_s337f_output(upipe, output, upump_p);
 }
 
 /** @internal @This sets the input flow definition.
@@ -352,31 +331,53 @@ static void upipe_s337f_input(struct upipe *upipe, struct uref *uref,
  */
 static int upipe_s337f_set_flow_def(struct upipe *upipe, struct uref *flow_def)
 {
+    struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
+
     if (flow_def == NULL)
         return UBASE_ERR_INVALID;
+
     const char *def;
-    uint64_t rate;
-    if (unlikely(!ubase_check(uref_flow_get_def(flow_def, &def)) ||
-                 (ubase_ncmp(def, "block.s337.") &&
-                  strcmp(def, "block.")) ||
-                 !ubase_check(uref_sound_flow_get_rate(flow_def, &rate))))
+    if (unlikely(!ubase_check(uref_flow_get_def(flow_def, &def))))
         return UBASE_ERR_INVALID;
 
-    struct uref *flow_def_dup;
-    if (unlikely((flow_def_dup = uref_dup(flow_def)) == NULL)) {
+    uint8_t bits;
+    if (!ubase_ncmp(def, "sound.s32.")) {
+        bits = 32;
+    } else if (!ubase_ncmp(def, "sound.s16.")) {
+        bits = 16;
+    } else {
+        return UBASE_ERR_INVALID;
+    }
+
+    if (bits == 32 && unlikely(!ubase_check(uref_sound_flow_get_raw_sample_size(flow_def, &bits)))) {
+        return UBASE_ERR_INVALID;
+    }
+
+    upipe_s337f->bits = bits;
+
+    uint8_t planes = 0;
+    if (unlikely(!ubase_check(uref_sound_flow_get_planes(flow_def, &planes) ||
+                    planes != 1)))
+        return UBASE_ERR_INVALID;
+
+    uint8_t channels = 0;
+    if (unlikely(!ubase_check(uref_sound_flow_get_channels(flow_def, &channels) ||
+                channels != 2)))
+        return UBASE_ERR_INVALID;
+
+    struct uref *flow_def_dup = uref_dup(flow_def);
+
+    if (unlikely(flow_def_dup == NULL)) {
         upipe_throw_fatal(upipe, UBASE_ERR_ALLOC);
         return UBASE_ERR_ALLOC;
     }
 
-    struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
-    upipe_s337f->sample_rate = rate;
     flow_def = upipe_s337f_store_flow_def_input(upipe, flow_def_dup);
-    if (flow_def != NULL)
-        upipe_s337f_store_flow_def(upipe, flow_def);
+
     return UBASE_ERR_NONE;
 }
 
-/** @internal @This processes control commands on a s337f pipe.
+/** @internal @This processes control commands.
  *
  * @param upipe description structure of the pipe
  * @param command type of command to process
@@ -385,6 +386,7 @@ static int upipe_s337f_set_flow_def(struct upipe *upipe, struct uref *flow_def)
  */
 static int upipe_s337f_control(struct upipe *upipe, int command, va_list args)
 {
+    struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
     switch (command) {
         case UPIPE_REGISTER_REQUEST: {
             struct urequest *request = va_arg(args, struct urequest *);
@@ -394,6 +396,7 @@ static int upipe_s337f_control(struct upipe *upipe, int command, va_list args)
             struct urequest *request = va_arg(args, struct urequest *);
             return upipe_s337f_free_output_proxy(upipe, request);
         }
+
         case UPIPE_GET_FLOW_DEF: {
             struct uref **p = va_arg(args, struct uref **);
             return upipe_s337f_get_flow_def(upipe, p);
@@ -410,30 +413,29 @@ static int upipe_s337f_control(struct upipe *upipe, int command, va_list args)
             struct upipe *output = va_arg(args, struct upipe *);
             return upipe_s337f_set_output(upipe, output);
         }
+
         default:
             return UBASE_ERR_UNHANDLED;
     }
 }
 
-/** @This frees a upipe.
+/** @internal @This frees all resources allocated.
  *
  * @param upipe description structure of the pipe
  */
 static void upipe_s337f_free(struct upipe *upipe)
 {
     struct upipe_s337f *upipe_s337f = upipe_s337f_from_upipe(upipe);
-    upipe_throw_dead(upipe);
 
-    upipe_s337f_clean_uref_stream(upipe);
+    upipe_throw_dead(upipe);
+    upipe_s337f_clean_urefcount(upipe);
     upipe_s337f_clean_output(upipe);
     upipe_s337f_clean_flow_def(upipe);
-    upipe_s337f_clean_sync(upipe);
+    uref_free(upipe_s337f->uref);
 
-    upipe_s337f_clean_urefcount(upipe);
     upipe_s337f_free_void(upipe);
 }
 
-/** module manager static descriptor */
 static struct upipe_mgr upipe_s337f_mgr = {
     .refcount = NULL,
     .signature = UPIPE_S337F_SIGNATURE,
@@ -443,10 +445,9 @@ static struct upipe_mgr upipe_s337f_mgr = {
     .upipe_control = upipe_s337f_control,
 
     .upipe_mgr_control = NULL
-
 };
 
-/** @This returns the management structure for all s337f pipes.
+/** @This returns the management structure for s337f pipes
  *
  * @return pointer to manager
  */


### PR DESCRIPTION
Operate on sound data rather than block, it better matches the
sources of S337 data which are:
    - straight from a SDI sound buffer
    - MPEG-TS S302 data decoded by libavcodec

If block output is needed it can still be piped into upipe_tblk.

Do not do reallocation in the framer and do 1 frame in 1 frame out.

Notes:
    - unlike previous module, guard bands are currently kept as-is.
      they should probably be removed and added back at output
    - 16 bits AES in s32 is not handled

TODO:
    - timestamps are not currently handled.
    - modify bitstream a bit to accomodate for 20/24 bits
    - test?