### PR TITLE
luajit: disable build by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,9 +13,6 @@ PKG_PROG_PKG_CONFIG
 
 # Checks for programs.
 AC_CHECK_PROGS(PERL, perl)
-AC_CHECK_PROGS(LUAJIT, luajit)
-AC_CHECK_PROGS(EU_READELF, eu-readelf)
-AC_CHECK_PROGS(LLVM_DWARFDUMP, [llvm-dwarfdump "xcrun llvm-dwarfdump"])
 AC_PATH_PROG(MOC, [moc-qt4 moc], moc)
 AC_PATH_PROG(YASM, yasm)
 AC_PROG_CXX
@@ -28,7 +25,17 @@ AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AM_PROG_CC_C_O
 LT_INIT([win32-dll])
-AM_CONDITIONAL(BUILD_LUAJIT, test "$OBJDUMP" != false -a "$enable_shared" != no)
+
+AC_ARG_ENABLE(
+    [luajit],
+    AS_HELP_STRING(
+        [--enable-luajit],
+        [Enable build of luajit bindings]))
+AM_CONDITIONAL(BUILD_LUAJIT, test "$enable_luajit" = yes -a "$OBJDUMP" != false -a "$enable_shared" != no)
+AM_COND_IF(BUILD_LUAJIT,
+           AC_CHECK_PROGS(LUAJIT, luajit)
+           AC_CHECK_PROGS(EU_READELF, eu-readelf)
+           AC_CHECK_PROGS(LLVM_DWARFDUMP, [llvm-dwarfdump "xcrun llvm-dwarfdump"]))
 
 YASMFLAGS=""
 ARCH_X86_64=0


### PR DESCRIPTION
Use ./configure --enable-luajit to explicitly enable luajit binding
build.