### PR TITLE
Ffmpeg

### DIFF
--- a/lib/upipe-av/upipe_avcodec_decode.c
+++ b/lib/upipe-av/upipe_avcodec_decode.c
@@ -84,7 +84,7 @@ static bool upipe_avcdec_decode_avpkt(struct upipe *upipe, AVPacket *avpkt,
 static bool upipe_avcdec_decode(struct upipe *upipe, struct uref *uref,
                                 struct upump **upump_p);
 
-/** upipe_avcdec structure with avcdec parameters */ 
+/** upipe_avcdec structure with avcdec parameters */
 struct upipe_avcdec {
     /** refcount management structure */
     struct urefcount urefcount;
@@ -215,17 +215,17 @@ static void upipe_av_uref_pic_free(void *opaque, uint8_t *data);
  * many data pointers as it can hold.  if CODEC_CAP_DR1 is not set then
  * get_buffer() must call avcodec_default_get_buffer() instead of providing
  * buffers allocated by some other means.
- * 
+ *
  * AVFrame.data[] should be 32- or 16-byte-aligned unless the CPU doesn't
  * need it.  avcodec_default_get_buffer() aligns the output buffer
  * properly, but if get_buffer() is overridden then alignment
  * considerations should be taken into account.
- * 
+ *
  * If pic.reference is set then the frame will be read later by libavcodec.
  * avcodec_align_dimensions2() should be used to find the required width
  * and height, as they normally need to be rounded up to the next multiple
  * of 16.
- * 
+ *
  * If frame multithreading is used and thread_safe_callbacks is set, it may
  * be called from a different thread, but not from more than one at once.
  * Does not need to be reentrant.
@@ -399,7 +399,7 @@ error:
 
 static void upipe_av_uref_pic_free(void *opaque, uint8_t *data)
 {
-	struct uref *uref = opaque;
+    struct uref *uref = opaque;
 
     uint64_t buffers;
     if (unlikely(!ubase_check(uref_attr_get_priv(uref, &buffers))))
@@ -572,7 +572,7 @@ static bool upipe_avcdec_do_av_deal(struct upipe *upipe)
     AVCodecContext *context = upipe_avcdec->context;
 
     if (upipe_avcdec->close) {
-        upipe_notice_va(upipe, "codec %s (%s) %d closed", context->codec->name, 
+        upipe_notice_va(upipe, "codec %s (%s) %d closed", context->codec->name,
                         context->codec->long_name, context->codec->id);
 
         if (upipe_avcdec->uref != NULL &&
@@ -614,7 +614,7 @@ static bool upipe_avcdec_do_av_deal(struct upipe *upipe)
         upipe_throw_fatal(upipe, UBASE_ERR_EXTERNAL);
         return false;
     }
-    upipe_notice_va(upipe, "codec %s (%s) %d opened", context->codec->name, 
+    upipe_notice_va(upipe, "codec %s (%s) %d opened", context->codec->name,
                     context->codec->long_name, context->codec->id);
 
     return true;
@@ -667,7 +667,7 @@ static void upipe_avcdec_start_av_deal(struct upipe *upipe)
     struct upipe_avcdec *upipe_avcdec = upipe_avcdec_from_upipe(upipe);
     /* abort a pending open request */
     upipe_avcdec_abort_av_deal(upipe);
- 
+
     /* use udeal/upump callback if available */
     upipe_avcdec_check_upump_mgr(upipe);
     if (upipe_avcdec->upump_mgr == NULL) {
@@ -927,7 +927,7 @@ static void upipe_avcdec_output_sub(struct upipe *upipe, AVSubtitle *sub,
             goto alloc_error;
         }
 
- #if LIBAVCODEC_VERSION_MAJOR < 59
+#if LIBAVCODEC_VERSION_MAJOR < 59
         uint8_t *src = r->pict.data[0];
         uint8_t *palette = r->pict.data[1];
 #else
@@ -1293,7 +1293,7 @@ static bool upipe_avcdec_decode(struct upipe *upipe, struct uref *uref,
         upipe_throw_fatal(upipe, UBASE_ERR_ALLOC);
         return true;
     }
-    uref_block_extract(uref, 0, avpkt.size, avpkt.data); 
+    uref_block_extract(uref, 0, avpkt.size, avpkt.data);
     ubuf_free(uref_detach_ubuf(uref));
     memset(avpkt.data + avpkt.size, 0, FF_INPUT_BUFFER_PADDING_SIZE);
 

--- a/lib/upipe-av/upipe_avformat_sink.c
+++ b/lib/upipe-av/upipe_avformat_sink.c
@@ -375,8 +375,8 @@ static int upipe_avfsink_sub_set_flow_def(struct upipe *upipe,
             codec->sample_aspect_ratio.den = sar.den;
         stream->avg_frame_rate.num = 25;
         stream->avg_frame_rate.den = 1;
-        codec->time_base.num = fps.den;
-        codec->time_base.den = fps.num * 2;
+        stream->time_base.num = fps.den;
+        stream->time_base.den = fps.num * 2;
         codec->ticks_per_frame = 2;
         codec->framerate.num = fps.num;
         codec->framerate.den = fps.den;
@@ -384,7 +384,7 @@ static int upipe_avfsink_sub_set_flow_def(struct upipe *upipe,
         codec->codec_type = AVMEDIA_TYPE_AUDIO;
         codec->channels = channels;
         codec->sample_rate = rate;
-        codec->time_base = (AVRational){ 1, codec->sample_rate };
+        stream->time_base = (AVRational){ 1, codec->sample_rate };
         codec->frame_size = samples;
     }
 

--- a/lib/upipe-av/upipe_avformat_source.c
+++ b/lib/upipe-av/upipe_avformat_source.c
@@ -768,9 +768,9 @@ static struct uref *alloc_video_def(struct upipe *upipe,
     UBASE_FATAL(upipe, uref_pic_flow_set_hsize(flow_def, codec->width))
     UBASE_FATAL(upipe, uref_pic_flow_set_vsize(flow_def, codec->height))
     int ticks = codec->ticks_per_frame ? codec->ticks_per_frame : 1;
-    if (codec->time_base.num) {
-        struct urational fps = { .num = codec->time_base.den,
-                                 .den = codec->time_base.num * ticks };
+    if (stream->time_base.num) {
+        struct urational fps = { .num = stream->time_base.den,
+                                 .den = stream->time_base.num * ticks };
         urational_simplify(&fps);
         UBASE_FATAL(upipe, uref_pic_flow_set_fps(flow_def, fps))
     }


### PR DESCRIPTION
A couple of FFmpeg API updates.

Refcounting seems to be mandatory since the introduction of the new decoding API (which we don't use yet).
Added refcounting for audio, but still missing subtitles refcounting.

AVCodecParameters stuff for avformat would like some testing.
Note: this breaks backward compatibility with FFmpeg < 3.1 so we might want to keep that commit around and apply it later