### PR TITLE
upipe_control_provide_request: handle (un)register request once

### DIFF
--- a/lib/upipe-av/upipe_avformat_sink.c
+++ b/lib/upipe-av/upipe_avformat_sink.c
@@ -909,9 +909,12 @@ static int upipe_avfsink_set_uri(struct upipe *upipe, const char *uri)
 static int upipe_avfsink_control(struct upipe *upipe, int command, va_list args)
 {
     UBASE_HANDLED_RETURN(upipe_avfsink_control_subs(upipe, command, args));
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
 
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_SET_FLOW_DEF: {
             struct uref *flow_def = va_arg(args, struct uref *);
             return upipe_avfsink_set_flow_def(upipe, flow_def);

--- a/lib/upipe-filters/upipe_filter_vanc.c
+++ b/lib/upipe-filters/upipe_filter_vanc.c
@@ -964,9 +964,11 @@ static int upipe_vanc_set_flow_def(struct upipe *upipe, struct uref *flow_def)
  */
 static int upipe_vanc_control(struct upipe *upipe, int command, va_list args)
 {
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
-
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_SET_FLOW_DEF: {
             struct uref *flow_def = va_arg(args, struct uref *);
             return upipe_vanc_set_flow_def(upipe, flow_def);

--- a/lib/upipe-hls/upipe_hls_master.c
+++ b/lib/upipe-hls/upipe_hls_master.c
@@ -446,9 +446,12 @@ static int upipe_hls_master_control(struct upipe *upipe,
                                     va_list args)
 {
     UBASE_HANDLED_RETURN(upipe_hls_master_control_pipes(upipe, command, args));
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
 
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
     case UPIPE_SET_FLOW_DEF: {
         struct uref *flow_def = va_arg(args, struct uref *);
         return upipe_hls_master_set_flow_def(upipe, flow_def);

--- a/lib/upipe-hls/upipe_hls_playlist.c
+++ b/lib/upipe-hls/upipe_hls_playlist.c
@@ -1044,9 +1044,12 @@ static int upipe_hls_playlist_control_internal(struct upipe *upipe,
 					       int command,
 					       va_list args)
 {
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
 
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
     case UPIPE_ATTACH_UCLOCK:
         return upipe_hls_playlist_attach_uclock(upipe);
 

--- a/lib/upipe-modules/upipe_audio_split.c
+++ b/lib/upipe-modules/upipe_audio_split.c
@@ -491,9 +491,12 @@ static int upipe_audio_split_control(struct upipe *upipe,
 {
     UBASE_HANDLED_RETURN(
         upipe_audio_split_control_outputs(upipe, command, args));
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
 
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_SET_FLOW_DEF: {
             struct uref *uref = va_arg(args, struct uref *);
             return upipe_audio_split_set_flow_def(upipe, uref);

--- a/lib/upipe-modules/upipe_file_sink.c
+++ b/lib/upipe-modules/upipe_file_sink.c
@@ -584,9 +584,11 @@ static int _upipe_fsink_get_sync_period(struct upipe *upipe, uint64_t *p)
  */
 static int  _upipe_fsink_control(struct upipe *upipe, int command, va_list args)
 {
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
-
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_ATTACH_UPUMP_MGR:
             upipe_fsink_set_upump(upipe, NULL);
             upipe_fsink_set_upump_sync(upipe, NULL);

--- a/lib/upipe-modules/upipe_null.c
+++ b/lib/upipe-modules/upipe_null.c
@@ -118,9 +118,11 @@ static int upipe_null_control(struct upipe *upipe, int command, va_list args)
 {
     struct upipe_null *upipe_null = upipe_null_from_upipe(upipe);
 
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
-
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_SET_FLOW_DEF:
             return UBASE_ERR_NONE;
 

--- a/lib/upipe-modules/upipe_rtp_h264.c
+++ b/lib/upipe-modules/upipe_rtp_h264.c
@@ -101,10 +101,11 @@ static int upipe_rtp_h264_set_flow_def(struct upipe *upipe,
 static int upipe_rtp_h264_control(struct upipe *upipe, int command,
                                   va_list args)
 {
-    //FIXME
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
-
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_SET_FLOW_DEF: {
             struct uref *flow_def = va_arg(args, struct uref *);
             return upipe_rtp_h264_set_flow_def(upipe, flow_def);

--- a/lib/upipe-modules/upipe_rtp_reorder.c
+++ b/lib/upipe-modules/upipe_rtp_reorder.c
@@ -243,10 +243,13 @@ static struct upipe *upipe_rtpr_sub_alloc(struct upipe_mgr *mgr,
 static int upipe_rtpr_sub_control(struct upipe *upipe,
                                          int command, va_list args)
 {
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
     UBASE_HANDLED_RETURN(upipe_rtpr_sub_control_super(upipe, command, args));
 
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_GET_FLOW_DEF: {
             struct uref **p = va_arg(args, struct uref **);
             return upipe_rtpr_sub_get_flow_def(upipe, p);

--- a/lib/upipe-modules/upipe_stream_switcher.c
+++ b/lib/upipe-modules/upipe_stream_switcher.c
@@ -278,11 +278,14 @@ static int upipe_stream_switcher_input_control(struct upipe *upipe,
         upipe_stream_switcher_from_sub_mgr(upipe_mgr);
     struct upipe *super = upipe_stream_switcher_to_upipe(upipe_stream_switcher);
 
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
     UBASE_HANDLED_RETURN(
         upipe_stream_switcher_input_control_super(upipe, command, args));
 
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
     case UPIPE_GET_MAX_LENGTH: {
         unsigned int *p = va_arg(args, unsigned int *);
         return upipe_stream_switcher_input_get_max_length(upipe, p);

--- a/lib/upipe-modules/upipe_udp_sink.c
+++ b/lib/upipe-modules/upipe_udp_sink.c
@@ -479,9 +479,11 @@ static int _upipe_udpsink_control(struct upipe *upipe,
 {
     struct upipe_udpsink *upipe_udpsink = upipe_udpsink_from_upipe(upipe);
 
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
-
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_ATTACH_UPUMP_MGR:
             upipe_udpsink_set_upump(upipe, NULL);
             return upipe_udpsink_attach_upump_mgr(upipe);

--- a/lib/upipe-osx/upipe_osx_audioqueue_sink.c
+++ b/lib/upipe-osx/upipe_osx_audioqueue_sink.c
@@ -523,9 +523,11 @@ static int upipe_osx_audioqueue_sink_check(struct upipe *upipe)
 static int upipe_osx_audioqueue_sink_control_real(struct upipe *upipe,
                                                   int command, va_list args)
 {
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
-
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_ATTACH_UPUMP_MGR:
             upipe_osx_audioqueue_sink_set_listener(upipe, NULL);
             upipe_osx_audioqueue_sink_set_watcher(upipe, NULL);

--- a/lib/upipe-ts/upipe_ts_demux.c
+++ b/lib/upipe-ts/upipe_ts_demux.c
@@ -2922,9 +2922,12 @@ static int upipe_ts_demux_control(struct upipe *upipe,
                                   int command, va_list args)
 {
     UBASE_HANDLED_RETURN(upipe_ts_demux_control_programs(upipe, command, args));
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
 
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_SET_FLOW_DEF: {
             struct uref *flow_def = va_arg(args, struct uref *);
             return upipe_ts_demux_set_flow_def(upipe, flow_def);

--- a/lib/upipe-ts/upipe_ts_scte35_probe.c
+++ b/lib/upipe-ts/upipe_ts_scte35_probe.c
@@ -357,9 +357,11 @@ static int upipe_ts_scte35p_set_flow_def(struct upipe *upipe,
 static int upipe_ts_scte35p_control(struct upipe *upipe,
                                     int command, va_list args)
 {
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
-
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_ATTACH_UPUMP_MGR:
             return upipe_ts_scte35p_attach_upump_mgr(upipe);
         case UPIPE_ATTACH_UCLOCK:

--- a/lib/upipe-ts/upipe_ts_tdt_decoder.c
+++ b/lib/upipe-ts/upipe_ts_tdt_decoder.c
@@ -143,9 +143,11 @@ static int upipe_ts_tdtd_set_flow_def(struct upipe *upipe,
  */
 static int upipe_ts_tdtd_control(struct upipe *upipe, int command, va_list args)
 {
-    UBASE_HANDLED_RETURN(upipe_control_provide_request(upipe, command, args));
-
     switch (command) {
+        case UPIPE_REGISTER_REQUEST:
+        case UPIPE_UNREGISTER_REQUEST:
+            return upipe_control_provide_request(upipe, command, args);
+
         case UPIPE_SET_FLOW_DEF: {
             struct uref *flow_def = va_arg(args, struct uref *);
             return upipe_ts_tdtd_set_flow_def(upipe, flow_def);


### PR DESCRIPTION
Make sure to handle register/unregister request once if
upipe_control_provide_request return UBASE_ERR_UNHANDLED.